### PR TITLE
chore: add missing .PHONY annotation to Makefile targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,8 @@ SCRIPTS_DIR ?= $(HOME)/Development/github.com/rios0rios0/pipelines
 -include $(SCRIPTS_DIR)/makefiles/common.mk
 -include $(SCRIPTS_DIR)/makefiles/golang.mk
 
+.PHONY: build debug build-musl run install
+
 build:
 	mkdir -p bin && rm -rf bin/terra
 	go mod tidy


### PR DESCRIPTION
## Summary
- Added `.PHONY` declaration for all Makefile targets (`build`, `debug`, `build-musl`, `run`, `install`) to prevent conflicts with files of the same name

## Test plan
- [ ] Verify `make` targets still work correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)