### PR TITLE
feat(selfupdate): added automatic version check on CLI startup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@ Exceptions are acceptable depending on the circumstances (critical bug fixes tha
 
 ## [Unreleased]
 
+### Added
+
+- added automatic version check on CLI startup using `CheckForUpdates()`
+
 ### Changed
 
 - changed the Go module dependencies to their latest versions

--- a/cmd/terra/main.go
+++ b/cmd/terra/main.go
@@ -4,6 +4,7 @@ import (
 	"os"
 
 	"github.com/joho/godotenv"
+	"github.com/rios0rios0/cliforge/pkg/selfupdate"
 	"github.com/rios0rios0/terra/internal/domain/commands"
 	"github.com/rios0rios0/terra/internal/domain/entities"
 	logger "github.com/sirupsen/logrus"
@@ -124,6 +125,8 @@ func main() {
 	// all other commands are added as subcommands
 	appContext := injectAppContext()
 	addSubcommands(cobraRoot, appContext)
+
+	selfupdate.NewCommand("rios0rios0", "terra", "terra", commands.TerraVersion).CheckForUpdates()
 
 	err = cobraRoot.Execute()
 	if err != nil {

--- a/cmd/terra/main.go
+++ b/cmd/terra/main.go
@@ -17,6 +17,20 @@ import (
 
 var version = "dev"
 
+// runUpdateCheck queries the cliforge selfupdate command for a newer version,
+// skipping local dev builds and the self-update / version subcommands to avoid
+// redundant GitHub API calls and noisy warnings.
+func runUpdateCheck(command *cobra.Command) {
+	if commands.TerraVersion == "dev" {
+		return
+	}
+	switch command.Name() {
+	case "self-update", "version":
+		return
+	}
+	selfupdate.NewCommand("rios0rios0", "terra", "terra", commands.TerraVersion).CheckForUpdates()
+}
+
 // buildRootCommand creates and configures the root cobra command.
 func buildRootCommand(rootController entities.Controller, enableFlagParsing bool) *cobra.Command {
 	bind := rootController.GetBind()
@@ -25,6 +39,9 @@ func buildRootCommand(rootController entities.Controller, enableFlagParsing bool
 		Use:   bind.Use,
 		Short: bind.Short,
 		Long:  bind.Long,
+		PersistentPreRun: func(command *cobra.Command, _ []string) {
+			runUpdateCheck(command)
+		},
 		Run: func(command *cobra.Command, arguments []string) {
 			rootController.Execute(command, arguments)
 		},
@@ -125,8 +142,6 @@ func main() {
 	// all other commands are added as subcommands
 	appContext := injectAppContext()
 	addSubcommands(cobraRoot, appContext)
-
-	selfupdate.NewCommand("rios0rios0", "terra", "terra", commands.TerraVersion).CheckForUpdates()
 
 	err = cobraRoot.Execute()
 	if err != nil {

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/go-playground/validator/v10 v10.30.2
 	github.com/joho/godotenv v1.5.1
 	github.com/kelseyhightower/envconfig v1.4.0
-	github.com/rios0rios0/cliforge v0.2.0
+	github.com/rios0rios0/cliforge v0.2.1-0.20260404230949-b9683f7eded2
 	github.com/rios0rios0/testkit v0.1.1
 	github.com/sirupsen/logrus v1.9.4
 	github.com/spf13/cobra v1.10.2

--- a/go.sum
+++ b/go.sum
@@ -32,8 +32,8 @@ github.com/leodido/go-urn v1.4.0/go.mod h1:bvxc+MVxLKB4z00jd1z+Dvzr47oO32F/QSNjS
 github.com/pkg/diff v0.0.0-20210226163009-20ebb0f2a09e/go.mod h1:pJLUxLENpZxwdsKMEsNbx1VGcRFpLqf3715MtcvvzbA=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
-github.com/rios0rios0/cliforge v0.2.0 h1:wy+bvUzsx1+ZXjOa9McLqppTQFPaSnx3ISf6EhW7Z2U=
-github.com/rios0rios0/cliforge v0.2.0/go.mod h1:xqHRf5C15as2KOOTXdyNZQnfExtXOpSkRljkhZ4hVsQ=
+github.com/rios0rios0/cliforge v0.2.1-0.20260404230949-b9683f7eded2 h1:cRuv/NTZ7B7UzTzO3JQy8VQlYxo45xC0RPhnVN6Ar7k=
+github.com/rios0rios0/cliforge v0.2.1-0.20260404230949-b9683f7eded2/go.mod h1:Ma0C18zImHW305Ezt+XCsmUmtSj3BM1mcBk7G5lttv0=
 github.com/rios0rios0/testkit v0.1.1 h1:EIMz9S2fo+19ESdQ7FL8bUap0Xf7Z2zlbgV6gnuHtd4=
 github.com/rios0rios0/testkit v0.1.1/go.mod h1:4yNptfPTrFn1TzsvZIvQjIia4PMl8hH8u+dqnLopmQA=
 github.com/rogpeppe/go-internal v1.9.0/go.mod h1:WtVeX8xhTBvf0smdhujwtBcq4Qrzq/fJaraNFVN+nFs=


### PR DESCRIPTION
## Summary
- Added `CheckForUpdates()` call on CLI startup to warn users when a newer version is available
- Updated `cliforge` dependency to include the new passive version check feature

## Test plan
- [ ] Verify CLI starts without errors
- [ ] Verify warning appears when running an outdated binary

🤖 Generated with [Claude Code](https://claude.com/claude-code)