### PR TITLE
feat(parallel): made --parallel/--all flag errors educational

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -164,6 +164,12 @@ terra apply --parallel=3 --only=module1,module2 /path/to/infrastructure
 # Exclude specific modules from parallel execution
 terra apply --parallel=3 --skip=excluded_module /path/to/infrastructure
 
+# Terragrunt-managed run-all: filter with terragrunt's --filter (preferred, strictly more expressive)
+terra apply --all --filter='!excluded_module' /path/to/infrastructure
+
+# Terragrunt-managed run-all: legacy filter syntax
+terra apply --all --queue-exclude-dir=excluded_module /path/to/infrastructure
+
 # Auto-reply to interactive prompts (defaults to "n")
 terra apply --reply=y /path/to/infrastructure/module
 terra apply -r=y /path/to/infrastructure/module
@@ -436,7 +442,8 @@ test/                    # Test helpers organized by domain/infrastructure layer
 - **Provider caching**: Terra uses the Terragrunt Provider Cache Server (`TG_PROVIDER_CACHE=1`) for concurrent-safe provider deduplication with file locking. This replaced `TF_PLUGIN_CACHE_DIR` which caused "text file busy" errors during parallel execution. Disable with `TERRA_NO_PROVIDER_CACHE=true`.
 - **Partial Parse Config Cache**: Terra enables the Terragrunt Partial Parse Config Cache by default (`TG_USE_PARTIAL_PARSE_CONFIG_CACHE=true`), which caches parsed HCL configs across modules sharing the same root include. Disable with `TERRA_NO_PARTIAL_PARSE_CACHE=true`.
 - **Auto-initialization with upgrade**: `UpgradeAwareShellRepository` wraps command execution. When a terragrunt command fails with output matching upgrade-needed patterns (backend changed, provider conflicts, uninitialized modules), it automatically runs `init --upgrade` and retries the original command. This is used in the normal (non-interactive) execution path of `RunFromRootCommand`.
-- **Parallel execution**: Two independent strategies exist. **Terra-managed**: `--parallel=N` runs terragrunt across multiple modules using N goroutine workers; use `--only=mod1,mod2` to select modules or `--skip=mod3` to exclude. **Terragrunt-managed**: `--all`, `--parallelism=N`, and `--filter=query` are forwarded directly to terragrunt for its native run-all behavior. These two strategies cannot be combined (`--parallel` and `--all` together is an error).
+- **Parallel execution**: Two independent strategies exist. **Terra-managed**: `--parallel=N` runs terragrunt across multiple modules using N goroutine workers; use `--only=mod1,mod2` to select modules or `--skip=mod3` to exclude. **Terragrunt-managed**: `--all`, `--parallelism=N`, and `--filter=query` (and the legacy `--queue-exclude-dir`/`--queue-include-dir`) are forwarded directly to terragrunt for its native run-all behavior. These two strategies cannot be combined (`--parallel` and `--all` together is an error). Terra's `--only`/`--skip` only work with `--parallel=N`; on the `--all` path you must use terragrunt's own filter flags (prefer `--filter='!mod'` which is strictly more expressive than `--queue-exclude-dir`).
+- **Educational validation errors**: When a user passes `--only`/`--skip` without `--parallel`, terra fatalfs with a multi-line error that echoes the command they typed and prints both valid escape hatches (`--parallel=5 --skip=mod` AND `--all --filter='!mod'`) as copy-pasteable examples. Same treatment for the `--parallel` + `--all` conflict. When a user passes terragrunt-only queue/filter flags (`--filter`, `--queue-exclude-dir`, `--queue-include-dir`) alongside `--parallel=N`, terra logs a non-fatal warning because the flags are silently ignored by the worker pool. These error builders live in `internal/domain/commands/run_from_root_error_builders.go` as `BuildSelectionFlagsError` and `BuildParallelAllConflictError`; update them (and the unit tests in `run_from_root_error_builders_test.go`) when changing validation messages.
 - **Reply mode**: Use `--reply=<value>` (or `-r=<value>`) to automatically answer interactive prompts from terragrunt. Uses `creack/pty` for PTY-based interaction.
 - **Pre-execution steps**: `RunAdditionalBeforeCommand` runs before the main terragrunt command: switches cloud account (if `TERRA_CLOUD` is set), initializes terraform (if not already done), and selects the workspace (if `TERRA_WORKSPACE` is set).
 - **Clearing caches**: `terra clear` removes local `.terraform` and `.terragrunt-cache` directories. Use `terra clear --global` to also remove the centralized cache directories.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,8 +16,15 @@ Exceptions are acceptable depending on the circumstances (critical bug fixes tha
 
 ## [Unreleased]
 
+### Added
+
+- added a non-fatal warning when terragrunt-only flags (`--filter`, `--queue-exclude-dir`, `--queue-include-dir`) are combined with terra's `--parallel=N`, since they are silently ignored by terra's worker pool; the warning nudges users toward `--only`/`--skip` or toward switching to `--all`
+
 ### Changed
 
+- changed the `--only`/`--skip` validation error to echo the user's command and show both valid forms (`--parallel=N --skip=mod1` and `--all --filter='!mod1'`), teaching the `--filter` alternative for the `--all` path instead of leaving users to discover terragrunt's native flags on their own
+- changed the `--parallel` + `--all` conflict error to echo the user's command and offer both alternative forms as copy-pasteable examples
+- changed the `terra --help` text to include a "Parallel execution strategies" block that summarizes when to use `--parallel=N` versus `--all`, making the split discoverable without reading the docs
 - changed the Go version to `1.26.2` and updated all module dependencies
 
 ## [1.13.0] - 2026-04-14

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -70,8 +70,9 @@ test/                  # Test helpers only (never in production folders)
 - **Provider caching:** Uses `TG_PROVIDER_CACHE` (Provider Cache Server) for concurrent-safe provider deduplication with file locking; disable with `TERRA_NO_PROVIDER_CACHE=true`
 - **Partial Parse Config Cache:** Enables `TG_USE_PARTIAL_PARSE_CONFIG_CACHE=true` by default (disable with `TERRA_NO_PARTIAL_PARSE_CACHE=true`)
 - **Auto-upgrade:** `UpgradeAwareShellRepository` detects backend/provider failures and retries with `init --upgrade`
-- **Parallel execution (terra-managed):** `--parallel=N` runs across modules via `ParallelStateCommand`; use `--only=mod1,mod2` to select modules or `--skip=mod3` to exclude them
-- **Parallel execution (terragrunt-managed):** `--all`, `--parallelism=N`, and `--filter=query` are forwarded to terragrunt as-is; `--parallel` and `--all` cannot be combined
+- **Parallel execution (terra-managed):** `--parallel=N` runs across modules via `ParallelStateCommand`; use `--only=mod1,mod2` to select modules or `--skip=mod3` to exclude them. These are terra-managed flags and only work with `--parallel=N`.
+- **Parallel execution (terragrunt-managed):** `--all`, `--parallelism=N`, and `--filter=query` are forwarded to terragrunt as-is. Filter modules on this path with terragrunt's `--filter='!mod'` (preferred) or `--queue-exclude-dir=mod`. `--parallel` and `--all` cannot be combined.
+- **Selection-flag errors are educational:** Using `--only`/`--skip` without `--parallel` is fatal; the error echoes the user's command and prints both valid forms (`--parallel=5 --skip=mod` AND `--all --filter='!mod'`). Using terragrunt's `--filter`/`--queue-exclude-dir`/`--queue-include-dir` with `--parallel` is non-fatal; it logs a warning because terra's worker pool silently ignores those flags. When editing validation, update `BuildSelectionFlagsError` / `BuildParallelAllConflictError` in `internal/domain/commands/run_from_root_error_builders.go`, not the call sites in `run_from_root_command.go`.
 - **Reply:** `--reply=<value>` (or `-r=<value>`) uses `creack/pty` for PTY-based prompt automation
 
 ## Testing Conventions

--- a/README.md
+++ b/README.md
@@ -155,9 +155,16 @@ terra destroy --parallel=4 -r /path
 
 ### Parallel Execution
 
-Terra provides two independent parallel execution strategies:
+Terra provides two independent parallel execution strategies. **They are not interchangeable** -- each one owns its own set of filter flags, and mixing them produces a validation error.
 
-**Terra-managed parallel** (`--parallel=N`) -- terra discovers modules and runs N goroutine workers:
+**Choosing a strategy:**
+
+- State operation (`state rm`, `import`, ...)? → must use `--parallel=N`. Terragrunt's `--all` does not support state commands.
+- Need terragrunt DAG ordering / `dependencies` block awareness? → must use `--all`.
+- Flat stack, want basename filtering? → either works; `--parallel=N` is simpler.
+- Need glob, graph, or git-diff filtering? → must use `--all` with terragrunt's `--filter`.
+
+**Terra-managed parallel** (`--parallel=N`) -- terra discovers modules and runs N goroutine workers. Filter modules with terra's `--only`/`--skip`:
 ```bash
 # Run init across all modules with 4 parallel threads
 terra init --parallel=4 /path/to/infrastructure
@@ -168,12 +175,12 @@ terra plan --parallel=4 --only=dev,staging,prod /path/to/infrastructure
 # Skip specific directories with --skip
 terra apply --parallel=4 --skip=test,backup /path/to/infrastructure
 
-# State commands
+# State commands (only --parallel supports these)
 terra import --parallel=4 null_resource.example resource-id /path/to/infrastructure
 terra state rm --parallel=2 null_resource.example /path/to/infrastructure
 ```
 
-**Terragrunt-managed parallel** (`--all` + `--parallelism`) -- forwarded directly to terragrunt:
+**Terragrunt-managed parallel** (`--all`) -- forwarded directly to terragrunt. Filter modules with terragrunt's `--filter` (preferred) or `--queue-exclude-dir`:
 ```bash
 # Terragrunt's native run-all
 terra apply --all /path/to/infrastructure
@@ -181,11 +188,25 @@ terra apply --all /path/to/infrastructure
 # Terragrunt's run-all with concurrency control
 terra plan --all --parallelism=4 /path/to/infrastructure
 
-# Terragrunt's run-all with filter
-terra apply --all --filter="region-us-east" /path/to/infrastructure
+# Terragrunt's run-all skipping a module with --filter (preferred)
+terra apply --all --filter='!1051-lab3' /path/to/infrastructure
+
+# Terragrunt's run-all skipping a module with the legacy flag
+terra apply --all --queue-exclude-dir=1051-lab3 /path/to/infrastructure
 ```
 
-> **Note:** `--parallel` and `--all` cannot be used together -- they represent competing execution strategies.
+**Filter equivalence table** -- use the column that matches your chosen strategy:
+
+| Intent                  | With `--parallel=N`  | With `--all`                          |
+|-------------------------|----------------------|---------------------------------------|
+| Skip one module         | `--skip=mod1`        | `--filter='!mod1'`                    |
+| Skip multiple           | `--skip=mod1,mod2`   | `--filter='!mod1' --filter='!mod2'`   |
+| Only specific modules   | `--only=mod1,mod2`   | `--filter='mod1' --filter='mod2'`     |
+| Path glob               | *(not supported)*    | `--filter='./prod/**'`                |
+| Graph expression        | *(not supported)*    | `--filter='service...'`               |
+| Git-diff expression     | *(not supported)*    | `--filter='[main...HEAD]'`            |
+
+> **Note:** `--parallel` and `--all` cannot be used together -- they represent competing execution strategies. Similarly, terra's `--only`/`--skip` only work with `--parallel`; passing them alongside `--all` produces an educational validation error that shows the `--filter` equivalent for your command. In the reverse direction, terragrunt-owned flags (`--filter`, `--queue-exclude-dir`, `--queue-include-dir`) trigger a warning when combined with `--parallel=N` because terra's worker pool silently ignores them.
 
 For comprehensive documentation, see [docs/parallel-execution.md](docs/parallel-execution.md). If you encounter Git clone errors (`BUG: refs/files-backend.c`) during parallel execution, see [docs/parallel-git-clone-race.md](docs/parallel-git-clone-race.md).
 

--- a/README.md
+++ b/README.md
@@ -159,7 +159,7 @@ Terra provides two independent parallel execution strategies. **They are not int
 
 **Choosing a strategy:**
 
-- State operation (`state rm`, `import`, ...)? → must use `--parallel=N`. Terragrunt's `--all` does not support state commands.
+- State operation across multiple modules from a root directory? → must use `--parallel=N`. Terragrunt's `--all` does not support state commands. Single-module state commands (e.g., `terra state rm <addr> /path/to/one/module`) still work without `--parallel`.
 - Need terragrunt DAG ordering / `dependencies` block awareness? → must use `--all`.
 - Flat stack, want basename filtering? → either works; `--parallel=N` is simpler.
 - Need glob, graph, or git-diff filtering? → must use `--all` with terragrunt's `--filter`.
@@ -175,7 +175,8 @@ terra plan --parallel=4 --only=dev,staging,prod /path/to/infrastructure
 # Skip specific directories with --skip
 terra apply --parallel=4 --skip=test,backup /path/to/infrastructure
 
-# State commands (only --parallel supports these)
+# State commands across a root with multiple modules use --parallel
+# (single-module state commands can still be forwarded without --parallel)
 terra import --parallel=4 null_resource.example resource-id /path/to/infrastructure
 terra state rm --parallel=2 null_resource.example /path/to/infrastructure
 ```

--- a/docs/parallel-execution.md
+++ b/docs/parallel-execution.md
@@ -120,7 +120,7 @@ terra apply --all --parallelism=4 --filter='region-us-east' /path/to/infrastruct
 
 Use this checklist to pick the right strategy before writing the command:
 
-1. **State operation (`state rm`, `import`, `state mv`, ...)?** → must use `--parallel=N`. Terragrunt's `--all` does not support state commands; terra rejects this combination.
+1. **State operation across multiple modules from a root directory?** → must use `--parallel=N`. Terragrunt's `--all` does not support state commands, and terra rejects that combination. Single-module state commands (e.g., `terra state rm <addr> /path/to/one/module`) still work without `--parallel` — terra just forwards them directly to terragrunt.
 2. **Need terragrunt DAG ordering / `dependencies` block awareness?** → must use `--all`. Terra's worker pool runs modules in parallel without resolving dependencies between them.
 3. **Flat stack, want simple basename filtering?** → either works. `--parallel=N` is slightly faster and its `--only`/`--skip` syntax is shorter for flat stacks.
 4. **Need glob, graph, or git-diff filtering?** → must use `--all` with terragrunt's `--filter`. Terra's `--only`/`--skip` only match literal basenames.

--- a/docs/parallel-execution.md
+++ b/docs/parallel-execution.md
@@ -92,27 +92,61 @@ terra init --parallel=4 --only=test1,test2,test3 /path
 
 ## Terragrunt's `--all` and `--parallelism`
 
-Terra's `--parallel=N` is separate from Terragrunt's native `--all` and `--parallelism` flags. They serve different purposes:
+Terra's `--parallel=N` is separate from Terragrunt's native `--all` and `--parallelism` flags. They serve different purposes and own different filter flags:
 
-| Flag | Owner | Purpose |
-|------|-------|---------|
-| `--parallel=N` | Terra | Terra manages goroutine workers across module directories |
-| `--all` | Terragrunt | Terragrunt's native run-all behavior (forwarded as-is) |
-| `--parallelism=N` | Terragrunt | Terragrunt's concurrency for `--all` (forwarded as-is) |
-| `--filter=query` | Terragrunt | Terragrunt's config filter language (forwarded as-is) |
+| Flag                   | Owner      | Purpose                                                              | Filter flags                    |
+|------------------------|------------|----------------------------------------------------------------------|---------------------------------|
+| `--parallel=N`         | Terra      | Terra manages goroutine workers across module directories           | `--only=mod1,mod2`, `--skip=mod1,mod2` |
+| `--all`                | Terragrunt | Terragrunt's native run-all behavior (forwarded as-is)              | `--filter`, `--queue-exclude-dir`, `--queue-include-dir` |
+| `--parallelism=N`      | Terragrunt | Terragrunt's concurrency for `--all` (forwarded as-is)              | n/a                             |
+| `--filter=query`       | Terragrunt | Terragrunt's expressive module filter (forwarded as-is)             | n/a                             |
 
 ```bash
 # Terra-managed parallel execution (terra discovers modules, runs N workers)
 terra plan --parallel=4 /path/to/infrastructure
+terra plan --parallel=4 --skip=mod1,mod2 /path/to/infrastructure
 
 # Terragrunt-managed run-all (forwarded directly to terragrunt)
 terra apply --all /path/to/infrastructure
+terra apply --all --filter='!mod1' /path/to/infrastructure
 
 # Terragrunt-managed run-all with parallelism and filter
-terra apply --all --parallelism=4 --filter="region-us-east" /path/to/infrastructure
+terra apply --all --parallelism=4 --filter='region-us-east' /path/to/infrastructure
 ```
 
 **Important:** `--parallel` and `--all` cannot be used together -- they represent competing execution strategies.
+
+## Choosing a strategy
+
+Use this checklist to pick the right strategy before writing the command:
+
+1. **State operation (`state rm`, `import`, `state mv`, ...)?** → must use `--parallel=N`. Terragrunt's `--all` does not support state commands; terra rejects this combination.
+2. **Need terragrunt DAG ordering / `dependencies` block awareness?** → must use `--all`. Terra's worker pool runs modules in parallel without resolving dependencies between them.
+3. **Flat stack, want simple basename filtering?** → either works. `--parallel=N` is slightly faster and its `--only`/`--skip` syntax is shorter for flat stacks.
+4. **Need glob, graph, or git-diff filtering?** → must use `--all` with terragrunt's `--filter`. Terra's `--only`/`--skip` only match literal basenames.
+
+## Filter equivalence table
+
+`--only`/`--skip` (terra-managed) and `--filter`/`--queue-exclude-dir` (terragrunt-managed) are **not interchangeable at runtime**, but they have equivalents for common cases. Use the column that matches the strategy you picked above:
+
+| Intent                  | With `--parallel=N`  | With `--all`                          |
+|-------------------------|----------------------|---------------------------------------|
+| Skip one module         | `--skip=mod1`        | `--filter='!mod1'`                    |
+| Skip multiple           | `--skip=mod1,mod2`   | `--filter='!mod1' --filter='!mod2'`   |
+| Only specific modules   | `--only=mod1,mod2`   | `--filter='mod1' --filter='mod2'`     |
+| Path glob               | *(not supported)*    | `--filter='./prod/**'`                |
+| Graph expression        | *(not supported)*    | `--filter='service...'`               |
+| Git-diff expression     | *(not supported)*    | `--filter='[main...HEAD]'`            |
+
+## Known differences between the two strategies
+
+Terra deliberately does **not** translate `--skip`/`--only` into `--queue-exclude-dir`/`--filter` on the `--all` path, and does not translate terragrunt's filter flags into terra's worker-pool selection on the `--parallel` path. There are three reasons:
+
+1. **Matching semantics differ.** Terra's `--skip=lab3` matches modules by basename anywhere in the subtree. Terragrunt's `--queue-exclude-dir=lab3` matches paths relative to the working directory and follows terragrunt-specific glob rules. Any automatic translation would either lie about semantics or require terra to walk the module tree itself, which defeats the purpose of `--all`.
+2. **Upstream parsing quirks.** [gruntwork-io/terragrunt#5124](https://github.com/gruntwork-io/terragrunt/issues/5124) documents that `--queue-exclude-dir` still parses excluded directories during dependency discovery. A module skipped by terra's native `--skip` is never touched; the same name forwarded to terragrunt's queue flag still goes through DAG parsing. Surfacing that divergence as a silent translation would cause subtle incidents in CI.
+3. **`--filter` is strictly more expressive.** Translating `--skip=a,b` to `--queue-exclude-dir` would downgrade capability for `--all` users who have access to graph and git-diff expressions.
+
+Instead, terra provides **discoverability**: when you use `--skip` with `--all`, the validation error echoes your command and shows the exact `--filter` form you should type. When you use terragrunt's `--filter`/`--queue-exclude-dir` with `--parallel=N`, terra logs a warning pointing you at `--only`/`--skip`.
 
 ## Interactive Commands Require `--reply`
 
@@ -181,7 +215,7 @@ terra plan --parallel=4 /path/to/infrastructure
 - **Native Integration**: No need for external tools like GNU parallel
 - **Error Handling**: Comprehensive error reporting and aggregation
 - **Logging**: Detailed progress and completion status for each module
-- **Clean Separation**: Terra's `--parallel` and Terragrunt's `--all`/`--parallelism`/`--filter` are independent and unambiguous
+- **Clean Separation**: Terra's `--parallel` and Terragrunt's `--all`/`--parallelism`/`--filter` are independent and unambiguous; mixing them produces educational validation errors that show the correct form for your command rather than silently doing the wrong thing
 
 ## Notes
 

--- a/internal/domain/commands/run_from_root_command.go
+++ b/internal/domain/commands/run_from_root_command.go
@@ -69,7 +69,7 @@ func (it *RunFromRootCommand) Execute(
 	}
 
 	// Validate flag combinations before execution
-	it.validateFlagCombinations(arguments)
+	it.validateFlagCombinations(arguments, targetPath)
 
 	// Check if this is a parallel command (either state command with --all or any command with --parallel=N)
 	if it.isParallelCommand(arguments) {
@@ -121,7 +121,7 @@ func (it *RunFromRootCommand) removeReplyFlag(arguments []string) []string {
 
 // validateFlagCombinations validates that flag combinations are correct.
 // Errors and exits if invalid combinations are detected.
-func (it *RunFromRootCommand) validateFlagCombinations(arguments []string) {
+func (it *RunFromRootCommand) validateFlagCombinations(arguments []string, targetPath string) {
 	it.validateDeprecatedFlags(arguments)
 
 	hasParallelFlag := HasParallelFlag(arguments)
@@ -129,10 +129,7 @@ func (it *RunFromRootCommand) validateFlagCombinations(arguments []string) {
 
 	// --parallel and --all cannot be used together (competing execution strategies)
 	if hasParallelFlag && hasAllFlag {
-		logger.Fatalf(
-			"Error: --parallel and --all cannot be used together. " +
-				"Use --parallel=N for terra's parallel execution, or --all for terragrunt's run-all.",
-		)
+		logger.Fatalf("%s", BuildParallelAllConflictError(arguments, targetPath))
 	}
 
 	// --reply is required when --parallel is used with interactive commands (apply, destroy)
@@ -156,6 +153,18 @@ func (it *RunFromRootCommand) validateFlagCombinations(arguments []string) {
 		)
 	}
 
+	// Warn when terragrunt queue/filter flags are combined with --parallel: they are
+	// silently ignored by terra's worker pool, which is the inverse misuse of the
+	// --only/--skip + --all error path. The warning nudges users to the right tool.
+	if hasParallelFlag && hasTerragruntQueueFlag(arguments) {
+		logger.Warnf(
+			"--filter, --queue-exclude-dir, and --queue-include-dir are terragrunt flags " +
+				"and have no effect with --parallel=N (terra-managed parallelism). " +
+				"Use --only=mod1,mod2 or --skip=mod1,mod2 for module selection, " +
+				"or switch to --all to let terragrunt handle filtering natively.",
+		)
+	}
+
 	// --reply requires an explicit value when used with --all (terragrunt-managed parallelism)
 	// because the PTY auto-answering needs to know whether to respond "y" or "n".
 	if hasAllFlag && HasReplyFlag(arguments) && !HasExplicitReplyValue(arguments) {
@@ -166,7 +175,16 @@ func (it *RunFromRootCommand) validateFlagCombinations(arguments []string) {
 		)
 	}
 
-	it.validateSelectionFlags(arguments, hasParallelFlag)
+	it.validateSelectionFlags(arguments, hasParallelFlag, targetPath)
+}
+
+// hasTerragruntQueueFlag returns true when any terragrunt-only queue/filter flag is
+// present. Used to warn when these flags are combined with terra's --parallel=N,
+// where they are silently ignored because terra manages module selection itself.
+func hasTerragruntQueueFlag(arguments []string) bool {
+	return HasFilterFlag(arguments) ||
+		HasQueueExcludeDirFlag(arguments) ||
+		HasQueueIncludeDirFlag(arguments)
 }
 
 // validateDeprecatedFlags detects removed/renamed flags and exits with migration guidance.
@@ -225,7 +243,11 @@ func (it *RunFromRootCommand) validateDeprecatedFlags(arguments []string) {
 }
 
 // validateSelectionFlags validates --only/--skip flag usage.
-func (it *RunFromRootCommand) validateSelectionFlags(arguments []string, hasParallelFlag bool) {
+func (it *RunFromRootCommand) validateSelectionFlags(
+	arguments []string,
+	hasParallelFlag bool,
+	targetPath string,
+) {
 	hasOnlyFlag := HasOnlyFlag(arguments)
 	hasSkipFlag := HasSkipFlag(arguments)
 
@@ -237,7 +259,7 @@ func (it *RunFromRootCommand) validateSelectionFlags(arguments []string, hasPara
 
 	// --only/--skip require --parallel=N
 	if !hasParallelFlag {
-		logger.Fatalf("Error: --only/--skip flags require --parallel=N.")
+		logger.Fatalf("%s", BuildSelectionFlagsError(arguments, targetPath))
 	}
 
 	it.validateSelectionFlagConflicts(arguments, hasOnlyFlag, hasSkipFlag)

--- a/internal/domain/commands/run_from_root_error_builders.go
+++ b/internal/domain/commands/run_from_root_error_builders.go
@@ -2,26 +2,106 @@ package commands
 
 import (
 	"fmt"
+	"slices"
 	"strings"
 )
 
-// extractSubcommand returns the first non-flag argument from the argument list,
-// which is the terragrunt subcommand (apply, plan, destroy, import, etc.). Returns
-// an empty string when no non-flag argument is present.
+// sensitiveFlagPrefixes lists terraform/terragrunt flags whose values commonly
+// carry secrets (variable values, backend credentials). Both single-dash and
+// double-dash variants are handled. When these flags appear in argv, the error
+// echo replaces their values with "<redacted>" so credentials cannot leak into
+// error logs or CI output. Note: "-var-file" is NOT included because its value
+// is a filename, not a secret.
+func sensitiveFlagPrefixes() []string {
+	return []string{
+		"-var",
+		"--var",
+		"-backend-config",
+		"--backend-config",
+	}
+}
+
+// extractSubcommand returns the terragrunt command prefix from the argument list.
+// For most commands this is the first non-flag argument (apply, plan, destroy,
+// import, etc.). For multi-word state commands it preserves the second token as
+// well (for example: "state rm", "state mv") so generated suggestions remain
+// copy-pasteable. Returns an empty string when no non-flag argument is present.
 func extractSubcommand(arguments []string) string {
-	for _, arg := range arguments {
-		if !strings.HasPrefix(arg, "-") {
+	for index, arg := range arguments {
+		if strings.HasPrefix(arg, "-") {
+			continue
+		}
+
+		if arg != "state" {
 			return arg
 		}
+
+		subcommandParts := []string{arg}
+		for _, nextArg := range arguments[index+1:] {
+			if strings.HasPrefix(nextArg, "-") {
+				continue
+			}
+
+			subcommandParts = append(subcommandParts, nextArg)
+			break
+		}
+
+		return strings.Join(subcommandParts, " ")
 	}
 	return ""
 }
 
+// sanitizeArgvForEcho returns a copy of arguments in which the values of known
+// sensitive flags (see sensitiveFlagPrefixes) are replaced with "<redacted>".
+// Both "-var=key=secret" and "-var key=secret" forms are handled. Filenames
+// (e.g. "-var-file=prod.tfvars") are left untouched.
+func sanitizeArgvForEcho(arguments []string) []string {
+	sanitized := make([]string, 0, len(arguments))
+	redactNext := false
+	for _, arg := range arguments {
+		if redactNext {
+			sanitized = append(sanitized, "<redacted>")
+			redactNext = false
+			continue
+		}
+		if prefix, matched := matchSensitiveFlagWithValue(arg); matched {
+			sanitized = append(sanitized, prefix+"=<redacted>")
+			continue
+		}
+		if isSensitiveFlagWithoutValue(arg) {
+			sanitized = append(sanitized, arg)
+			redactNext = true
+			continue
+		}
+		sanitized = append(sanitized, arg)
+	}
+	return sanitized
+}
+
+// matchSensitiveFlagWithValue returns the flag prefix (e.g. "-var") and true when
+// the argument matches the "<flag>=<value>" form of a sensitive flag.
+func matchSensitiveFlagWithValue(arg string) (string, bool) {
+	for _, prefix := range sensitiveFlagPrefixes() {
+		if strings.HasPrefix(arg, prefix+"=") {
+			return prefix, true
+		}
+	}
+	return "", false
+}
+
+// isSensitiveFlagWithoutValue returns true when the argument is exactly a sensitive
+// flag name (e.g. "-var"), indicating the next argument carries its value.
+func isSensitiveFlagWithoutValue(arg string) bool {
+	return slices.Contains(sensitiveFlagPrefixes(), arg)
+}
+
 // buildEchoedCommand reconstructs the command the user typed so the error message
-// can quote it back verbatim. Format: "terra <arguments joined> <targetPath>".
+// can quote it back. Values of known sensitive flags (-var, -backend-config) are
+// redacted so credentials cannot leak into error output. Format:
+// "terra <sanitized arguments joined> <targetPath>".
 func buildEchoedCommand(arguments []string, targetPath string) string {
 	parts := []string{"terra"}
-	parts = append(parts, arguments...)
+	parts = append(parts, sanitizeArgvForEcho(arguments)...)
 	if targetPath != "" {
 		parts = append(parts, targetPath)
 	}

--- a/internal/domain/commands/run_from_root_error_builders.go
+++ b/internal/domain/commands/run_from_root_error_builders.go
@@ -1,0 +1,152 @@
+package commands
+
+import (
+	"fmt"
+	"strings"
+)
+
+// extractSubcommand returns the first non-flag argument from the argument list,
+// which is the terragrunt subcommand (apply, plan, destroy, import, etc.). Returns
+// an empty string when no non-flag argument is present.
+func extractSubcommand(arguments []string) string {
+	for _, arg := range arguments {
+		if !strings.HasPrefix(arg, "-") {
+			return arg
+		}
+	}
+	return ""
+}
+
+// buildEchoedCommand reconstructs the command the user typed so the error message
+// can quote it back verbatim. Format: "terra <arguments joined> <targetPath>".
+func buildEchoedCommand(arguments []string, targetPath string) string {
+	parts := []string{"terra"}
+	parts = append(parts, arguments...)
+	if targetPath != "" {
+		parts = append(parts, targetPath)
+	}
+	return strings.Join(parts, " ")
+}
+
+// buildParallelSuggestion builds the terra-managed parallel form of the user's intent,
+// suitable as a copy-pasteable example in a validation error. --reply is appended only
+// when the command is interactive (apply/destroy), because terra rejects those without it.
+func buildParallelSuggestion(
+	subcommand string,
+	onlyValues, skipValues []string,
+	needsReply bool,
+	targetPath string,
+) string {
+	parts := []string{"terra"}
+	if subcommand != "" {
+		parts = append(parts, subcommand)
+	}
+	parts = append(parts, "--parallel=5")
+	if len(onlyValues) > 0 {
+		parts = append(parts, "--only="+strings.Join(onlyValues, ","))
+	}
+	if len(skipValues) > 0 {
+		parts = append(parts, "--skip="+strings.Join(skipValues, ","))
+	}
+	if needsReply {
+		parts = append(parts, "--reply")
+	}
+	if targetPath != "" {
+		parts = append(parts, targetPath)
+	}
+	return strings.Join(parts, " ")
+}
+
+// buildAllWithFilterSuggestion builds the terragrunt-managed run-all form of the user's
+// intent, using terragrunt's --filter as the module selector. --only values map to
+// positive filters, --skip values map to negated filters prefixed with '!'.
+func buildAllWithFilterSuggestion(
+	subcommand string,
+	onlyValues, skipValues []string,
+	targetPath string,
+) string {
+	parts := []string{"terra"}
+	if subcommand != "" {
+		parts = append(parts, subcommand)
+	}
+	parts = append(parts, "--all")
+	for _, value := range onlyValues {
+		parts = append(parts, fmt.Sprintf("--filter='%s'", value))
+	}
+	for _, value := range skipValues {
+		parts = append(parts, fmt.Sprintf("--filter='!%s'", value))
+	}
+	if targetPath != "" {
+		parts = append(parts, targetPath)
+	}
+	return strings.Join(parts, " ")
+}
+
+// BuildSelectionFlagsError produces an educational error message when --only or --skip
+// is used without --parallel=N. It echoes the user's command verbatim and shows both
+// valid alternative forms (terra-managed --parallel and terragrunt-managed --all --filter)
+// with the user's own module values substituted.
+func BuildSelectionFlagsError(arguments []string, targetPath string) string {
+	subcommand := extractSubcommand(arguments)
+	onlyValues, _ := GetOnlyValues(arguments)
+	skipValues, _ := GetSkipValues(arguments)
+	needsReply := IsInteractiveCommand(arguments)
+
+	echoed := buildEchoedCommand(arguments, targetPath)
+	parallelSuggestion := buildParallelSuggestion(
+		subcommand, onlyValues, skipValues, needsReply, targetPath,
+	)
+	allSuggestion := buildAllWithFilterSuggestion(subcommand, onlyValues, skipValues, targetPath)
+
+	return fmt.Sprintf(
+		"Error: --only/--skip are terra-managed flags and require --parallel=N.\n"+
+			"You used: %s\n"+
+			"\n"+
+			"Terra has two separate parallel-execution strategies. "+
+			"--only/--skip only work with the first:\n"+
+			"\n"+
+			"  1) Terra-managed worker pool (simple basename matching across the tree):\n"+
+			"       %s\n"+
+			"\n"+
+			"  2) Terragrunt-managed run-all "+
+			"(DAG-aware; supports path globs, graph and git-diff expressions):\n"+
+			"       %s\n"+
+			"\n"+
+			"Terragrunt's --filter is strictly more expressive than terra's --skip/--only.\n"+
+			"See docs/parallel-execution.md for the full comparison.",
+		echoed, parallelSuggestion, allSuggestion,
+	)
+}
+
+// BuildParallelAllConflictError produces an educational error message when --parallel
+// and --all are combined. It echoes the user's command and shows both valid forms so
+// the user can pick one without re-reading the documentation.
+func BuildParallelAllConflictError(arguments []string, targetPath string) string {
+	subcommand := extractSubcommand(arguments)
+	onlyValues, _ := GetOnlyValues(arguments)
+	skipValues, _ := GetSkipValues(arguments)
+	needsReply := IsInteractiveCommand(arguments)
+
+	echoed := buildEchoedCommand(arguments, targetPath)
+	parallelSuggestion := buildParallelSuggestion(
+		subcommand, onlyValues, skipValues, needsReply, targetPath,
+	)
+	allSuggestion := buildAllWithFilterSuggestion(subcommand, onlyValues, skipValues, targetPath)
+
+	return fmt.Sprintf(
+		"Error: --parallel and --all cannot be used together "+
+			"(competing execution strategies).\n"+
+			"You used: %s\n"+
+			"\n"+
+			"Pick one strategy:\n"+
+			"\n"+
+			"  1) Terra-managed worker pool (drop --all):\n"+
+			"       %s\n"+
+			"\n"+
+			"  2) Terragrunt-managed run-all (drop --parallel=N):\n"+
+			"       %s\n"+
+			"\n"+
+			"See docs/parallel-execution.md for when to use each.",
+		echoed, parallelSuggestion, allSuggestion,
+	)
+}

--- a/internal/domain/commands/run_from_root_error_builders_test.go
+++ b/internal/domain/commands/run_from_root_error_builders_test.go
@@ -1,0 +1,195 @@
+//go:build unit
+
+package commands_test
+
+import (
+	"testing"
+
+	"github.com/rios0rios0/terra/internal/domain/commands"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestBuildSelectionFlagsError(t *testing.T) {
+	t.Parallel()
+
+	t.Run("should echo the user command verbatim in the error", func(t *testing.T) {
+		t.Parallel()
+		// GIVEN: The arguments a user would pass on the terra CLI
+		arguments := []string{"apply", "--all", "--skip=1051-lab3"}
+		targetPath := "environments/05_dfir_iris/dev"
+
+		// WHEN: Building the selection-flags error
+		message := commands.BuildSelectionFlagsError(arguments, targetPath)
+
+		// THEN: The error includes the exact command the user typed
+		assert.Contains(
+			t,
+			message,
+			"You used: terra apply --all --skip=1051-lab3 environments/05_dfir_iris/dev",
+		)
+	})
+
+	t.Run("should suggest --parallel=5 with user's skip values", func(t *testing.T) {
+		t.Parallel()
+		// GIVEN: A --skip invocation without --parallel
+		arguments := []string{"plan", "--skip=mod1,mod2"}
+		targetPath := "/infra"
+
+		// WHEN: Building the error
+		message := commands.BuildSelectionFlagsError(arguments, targetPath)
+
+		// THEN: The --parallel suggestion preserves the skip values verbatim
+		assert.Contains(t, message, "terra plan --parallel=5 --skip=mod1,mod2 /infra")
+	})
+
+	t.Run("should suggest --filter='!value' with negation for each skip value", func(t *testing.T) {
+		t.Parallel()
+		// GIVEN: A --skip invocation
+		arguments := []string{"plan", "--skip=mod1,mod2"}
+		targetPath := "/infra"
+
+		// WHEN: Building the error
+		message := commands.BuildSelectionFlagsError(arguments, targetPath)
+
+		// THEN: The --filter suggestion negates each skip value with '!'
+		assert.Contains(t, message, "terra plan --all --filter='!mod1' --filter='!mod2' /infra")
+	})
+
+	t.Run("should suggest --filter='value' positively for each only value", func(t *testing.T) {
+		t.Parallel()
+		// GIVEN: An --only invocation
+		arguments := []string{"plan", "--only=mod1,mod2"}
+		targetPath := "/infra"
+
+		// WHEN: Building the error
+		message := commands.BuildSelectionFlagsError(arguments, targetPath)
+
+		// THEN: The --filter suggestion uses positive values without '!'
+		assert.Contains(t, message, "terra plan --all --filter='mod1' --filter='mod2' /infra")
+	})
+
+	t.Run("should include --reply in the --parallel suggestion for apply", func(t *testing.T) {
+		t.Parallel()
+		// GIVEN: apply is an interactive command and terra requires --reply for it
+		arguments := []string{"apply", "--skip=mod1"}
+		targetPath := "/infra"
+
+		// WHEN: Building the error
+		message := commands.BuildSelectionFlagsError(arguments, targetPath)
+
+		// THEN: The --parallel suggestion includes --reply
+		assert.Contains(t, message, "terra apply --parallel=5 --skip=mod1 --reply /infra")
+	})
+
+	t.Run("should include --reply in the --parallel suggestion for destroy", func(t *testing.T) {
+		t.Parallel()
+		// GIVEN: destroy is also interactive
+		arguments := []string{"destroy", "--only=mod1"}
+		targetPath := "/infra"
+
+		// WHEN: Building the error
+		message := commands.BuildSelectionFlagsError(arguments, targetPath)
+
+		// THEN: The --parallel suggestion includes --reply
+		assert.Contains(t, message, "terra destroy --parallel=5 --only=mod1 --reply /infra")
+	})
+
+	t.Run("should NOT include --reply in the --parallel suggestion for plan", func(t *testing.T) {
+		t.Parallel()
+		// GIVEN: plan is not an interactive command
+		arguments := []string{"plan", "--skip=mod1"}
+		targetPath := "/infra"
+
+		// WHEN: Building the error
+		message := commands.BuildSelectionFlagsError(arguments, targetPath)
+
+		// THEN: The --parallel suggestion does NOT include --reply
+		assert.Contains(t, message, "terra plan --parallel=5 --skip=mod1 /infra")
+		assert.NotContains(t, message, "terra plan --parallel=5 --skip=mod1 --reply")
+	})
+
+	t.Run("should preserve the target path in both suggestion lines", func(t *testing.T) {
+		t.Parallel()
+		// GIVEN: A nested target path
+		arguments := []string{"plan", "--skip=mod1"}
+		targetPath := "/home/vsts/work/1/s/environments/05_dfir_iris/dev"
+
+		// WHEN: Building the error
+		message := commands.BuildSelectionFlagsError(arguments, targetPath)
+
+		// THEN: Both suggestion lines end with the target path
+		assert.Contains(
+			t,
+			message,
+			"terra plan --parallel=5 --skip=mod1 /home/vsts/work/1/s/environments/05_dfir_iris/dev",
+		)
+		assert.Contains(
+			t,
+			message,
+			"terra plan --all --filter='!mod1' /home/vsts/work/1/s/environments/05_dfir_iris/dev",
+		)
+	})
+
+	t.Run("should handle --only and --skip together", func(t *testing.T) {
+		t.Parallel()
+		// GIVEN: Both --only and --skip are present
+		arguments := []string{"plan", "--only=a,b", "--skip=c"}
+		targetPath := "/infra"
+
+		// WHEN: Building the error
+		message := commands.BuildSelectionFlagsError(arguments, targetPath)
+
+		// THEN: The --parallel suggestion includes both, and the --filter
+		// suggestion emits positive filters for --only and negated filters for --skip
+		assert.Contains(t, message, "terra plan --parallel=5 --only=a,b --skip=c /infra")
+		assert.Contains(
+			t,
+			message,
+			"terra plan --all --filter='a' --filter='b' --filter='!c' /infra",
+		)
+	})
+
+	t.Run("should reference docs/parallel-execution.md for further reading", func(t *testing.T) {
+		t.Parallel()
+		// GIVEN: Any selection-flag error
+		arguments := []string{"plan", "--skip=mod1"}
+		targetPath := "/infra"
+
+		// WHEN: Building the error
+		message := commands.BuildSelectionFlagsError(arguments, targetPath)
+
+		// THEN: The error points at the documentation
+		assert.Contains(t, message, "docs/parallel-execution.md")
+	})
+}
+
+func TestBuildParallelAllConflictError(t *testing.T) {
+	t.Parallel()
+
+	t.Run("should echo the user command in the error", func(t *testing.T) {
+		t.Parallel()
+		// GIVEN: A command that combines --parallel and --all
+		arguments := []string{"plan", "--parallel=5", "--all"}
+		targetPath := "/infra"
+
+		// WHEN: Building the error
+		message := commands.BuildParallelAllConflictError(arguments, targetPath)
+
+		// THEN: The error includes the exact command the user typed
+		assert.Contains(t, message, "You used: terra plan --parallel=5 --all /infra")
+	})
+
+	t.Run("should show both the --parallel=N and --all alternatives", func(t *testing.T) {
+		t.Parallel()
+		// GIVEN: A command that combines both strategies
+		arguments := []string{"plan", "--parallel=5", "--all"}
+		targetPath := "/infra"
+
+		// WHEN: Building the error
+		message := commands.BuildParallelAllConflictError(arguments, targetPath)
+
+		// THEN: Both alternative forms are present, each ending with the target path
+		assert.Contains(t, message, "terra plan --parallel=5 /infra")
+		assert.Contains(t, message, "terra plan --all /infra")
+	})
+}

--- a/internal/domain/commands/run_from_root_error_builders_test.go
+++ b/internal/domain/commands/run_from_root_error_builders_test.go
@@ -161,6 +161,100 @@ func TestBuildSelectionFlagsError(t *testing.T) {
 		// THEN: The error points at the documentation
 		assert.Contains(t, message, "docs/parallel-execution.md")
 	})
+
+	t.Run("should preserve 'state rm' in suggestions for state commands", func(t *testing.T) {
+		t.Parallel()
+		// GIVEN: A state rm invocation with --skip (two-word subcommand)
+		arguments := []string{"state", "rm", "--skip=mod1", "null_resource.foo"}
+		targetPath := "/infra"
+
+		// WHEN: Building the error
+		message := commands.BuildSelectionFlagsError(arguments, targetPath)
+
+		// THEN: Both suggestions preserve the full "state rm" prefix so the
+		// user can copy-paste them without producing broken syntax
+		assert.Contains(t, message, "terra state rm --parallel=5 --skip=mod1 /infra")
+		assert.Contains(t, message, "terra state rm --all --filter='!mod1' /infra")
+	})
+
+	t.Run("should preserve 'state mv' in suggestions for state commands", func(t *testing.T) {
+		t.Parallel()
+		// GIVEN: A state mv invocation with --skip
+		arguments := []string{"state", "mv", "--only=mod1"}
+		targetPath := "/infra"
+
+		// WHEN: Building the error
+		message := commands.BuildSelectionFlagsError(arguments, targetPath)
+
+		// THEN: Both suggestions include "state mv"
+		assert.Contains(t, message, "terra state mv --parallel=5 --only=mod1 /infra")
+		assert.Contains(t, message, "terra state mv --all --filter='mod1' /infra")
+	})
+
+	t.Run("should redact -var secret values in the echoed command", func(t *testing.T) {
+		t.Parallel()
+		// GIVEN: A command that passes a sensitive -var flag alongside --skip
+		arguments := []string{"apply", "--all", "-var=db_password=s3cret", "--skip=mod1"}
+		targetPath := "/infra"
+
+		// WHEN: Building the error
+		message := commands.BuildSelectionFlagsError(arguments, targetPath)
+
+		// THEN: The echoed command does not contain the secret, but still keeps
+		// the structure so the user can see what they typed
+		assert.NotContains(t, message, "s3cret")
+		assert.Contains(t, message, "-var=<redacted>")
+		assert.Contains(
+			t,
+			message,
+			"You used: terra apply --all -var=<redacted> --skip=mod1 /infra",
+		)
+	})
+
+	t.Run("should redact space-separated -var secret values", func(t *testing.T) {
+		t.Parallel()
+		// GIVEN: A command that uses the space-separated -var form
+		arguments := []string{"apply", "--all", "-var", "db_password=s3cret", "--skip=mod1"}
+		targetPath := "/infra"
+
+		// WHEN: Building the error
+		message := commands.BuildSelectionFlagsError(arguments, targetPath)
+
+		// THEN: The token after -var is redacted, not the flag itself
+		assert.NotContains(t, message, "s3cret")
+		assert.Contains(t, message, "-var <redacted>")
+	})
+
+	t.Run("should redact -backend-config secret values", func(t *testing.T) {
+		t.Parallel()
+		// GIVEN: A command that passes a sensitive -backend-config flag
+		arguments := []string{
+			"apply", "--all",
+			"-backend-config=access_key=AKIA1234", "--skip=mod1",
+		}
+		targetPath := "/infra"
+
+		// WHEN: Building the error
+		message := commands.BuildSelectionFlagsError(arguments, targetPath)
+
+		// THEN: The access key is redacted
+		assert.NotContains(t, message, "AKIA1234")
+		assert.Contains(t, message, "-backend-config=<redacted>")
+	})
+
+	t.Run("should NOT redact -var-file paths", func(t *testing.T) {
+		t.Parallel()
+		// GIVEN: A command that passes -var-file (a filename, not a secret)
+		arguments := []string{"apply", "--all", "-var-file=prod.tfvars", "--skip=mod1"}
+		targetPath := "/infra"
+
+		// WHEN: Building the error
+		message := commands.BuildSelectionFlagsError(arguments, targetPath)
+
+		// THEN: The -var-file argument is preserved verbatim
+		assert.Contains(t, message, "-var-file=prod.tfvars")
+		assert.NotContains(t, message, "-var-file=<redacted>")
+	})
 }
 
 func TestBuildParallelAllConflictError(t *testing.T) {

--- a/internal/domain/commands/run_from_root_validation_test.go
+++ b/internal/domain/commands/run_from_root_validation_test.go
@@ -3,6 +3,7 @@
 package commands_test
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/rios0rios0/terra/internal/domain/commands"
@@ -206,11 +207,14 @@ func TestRunFromRootCommand_validateFlagCombinations(t *testing.T) {
 		// WHEN: Executing the command
 		cmd.Execute("/test/path", arguments, dependencies)
 
-		// THEN: Should log a fatal error about conflicting flags
+		// THEN: Should log a fatal error about conflicting flags with educational details
 		require.NotEmpty(t, hook.Entries)
 		lastEntry := hook.LastEntry()
 		assert.Equal(t, logger.FatalLevel, lastEntry.Level)
 		assert.Contains(t, lastEntry.Message, "--parallel and --all cannot be used together")
+		assert.Contains(t, lastEntry.Message, "You used: terra plan --parallel=5 --all /test/path")
+		assert.Contains(t, lastEntry.Message, "terra plan --parallel=5 /test/path")
+		assert.Contains(t, lastEntry.Message, "terra plan --all /test/path")
 	})
 
 	t.Run("should fatalf when --parallel is used with apply without --reply", func(t *testing.T) {
@@ -390,11 +394,14 @@ func TestRunFromRootCommand_validateSelectionFlags(t *testing.T) {
 		// WHEN: Executing the command
 		cmd.Execute("/test/path", arguments, dependencies)
 
-		// THEN: Should log a fatal error about missing --parallel flag
+		// THEN: Should log a fatal error that teaches both escape hatches
 		require.NotEmpty(t, hook.Entries)
 		lastEntry := hook.LastEntry()
 		assert.Equal(t, logger.FatalLevel, lastEntry.Level)
-		assert.Contains(t, lastEntry.Message, "--only/--skip flags require --parallel=N")
+		assert.Contains(t, lastEntry.Message, "--only/--skip are terra-managed flags")
+		assert.Contains(t, lastEntry.Message, "You used: terra plan --only=mod1,mod2 /test/path")
+		assert.Contains(t, lastEntry.Message, "terra plan --parallel=5 --only=mod1,mod2 /test/path")
+		assert.Contains(t, lastEntry.Message, "terra plan --all --filter='mod1' --filter='mod2' /test/path")
 	})
 
 	t.Run("should fatalf when --skip is used without --parallel", func(t *testing.T) {
@@ -408,11 +415,172 @@ func TestRunFromRootCommand_validateSelectionFlags(t *testing.T) {
 		// WHEN: Executing the command
 		cmd.Execute("/test/path", arguments, dependencies)
 
-		// THEN: Should log a fatal error about missing --parallel flag
+		// THEN: Should log a fatal error that teaches both escape hatches and
+		// negates the skip value for the --filter suggestion
 		require.NotEmpty(t, hook.Entries)
 		lastEntry := hook.LastEntry()
 		assert.Equal(t, logger.FatalLevel, lastEntry.Level)
-		assert.Contains(t, lastEntry.Message, "--only/--skip flags require --parallel=N")
+		assert.Contains(t, lastEntry.Message, "--only/--skip are terra-managed flags")
+		assert.Contains(t, lastEntry.Message, "You used: terra plan --skip=mod1 /test/path")
+		assert.Contains(t, lastEntry.Message, "terra plan --parallel=5 --skip=mod1 /test/path")
+		assert.Contains(t, lastEntry.Message, "terra plan --all --filter='!mod1' /test/path")
+	})
+
+	t.Run("should include --reply in the --parallel suggestion for apply", func(t *testing.T) {
+		// GIVEN: apply with --skip but without --parallel (and without --all)
+		hook, cleanup := setupFatalInterceptor()
+		defer cleanup()
+		cmd := newRunFromRootForValidation()
+		arguments := []string{"apply", "--skip=mod1"}
+		dependencies := []entities.Dependency{}
+
+		// WHEN: Executing the command
+		cmd.Execute("/test/path", arguments, dependencies)
+
+		// THEN: The suggestion for the --parallel path includes --reply because
+		// apply is interactive and terra rejects --parallel apply without it
+		require.NotEmpty(t, hook.Entries)
+		lastEntry := hook.LastEntry()
+		assert.Equal(t, logger.FatalLevel, lastEntry.Level)
+		assert.Contains(
+			t,
+			lastEntry.Message,
+			"terra apply --parallel=5 --skip=mod1 --reply /test/path",
+		)
+	})
+}
+
+func TestRunFromRootCommand_warnWhenTerragruntQueueFlagsUsedWithParallel(t *testing.T) {
+	t.Run("should warn when --filter is used with --parallel", func(t *testing.T) {
+		// GIVEN: A terra-managed parallel command that also passes terragrunt's --filter
+		hook, cleanup := setupFatalInterceptor()
+		defer cleanup()
+
+		parallelState := &commanddoubles.StubParallelState{}
+		cmd := commands.NewRunFromRootCommand(
+			entitybuilders.NewSettingsBuilder().
+				WithTerraModuleCacheDir("/tmp/terra-test-modules").
+				WithTerraProviderCacheDir("/tmp/terra-test-providers").
+				BuildSettings(),
+			&commanddoubles.StubInstallDependencies{},
+			&commanddoubles.StubFormatFiles{},
+			&commanddoubles.StubRunAdditionalBefore{},
+			parallelState,
+			&repositorydoubles.StubShellRepositoryForRoot{},
+			&repositorydoubles.StubUpgradeShellRepository{},
+			&repositorydoubles.StubInteractiveShellRepository{},
+		)
+		arguments := []string{"plan", "--parallel=3", "--filter=foo"}
+		dependencies := []entities.Dependency{}
+
+		// WHEN: Executing the command
+		cmd.Execute("/test/path", arguments, dependencies)
+
+		// THEN: Should log a non-fatal warning about the ignored terragrunt flag
+		// and still proceed to parallel execution
+		var foundWarning bool
+		for _, entry := range hook.Entries {
+			if entry.Level == logger.WarnLevel &&
+				strings.Contains(
+					entry.Message,
+					"--filter, --queue-exclude-dir, and --queue-include-dir are terragrunt flags",
+				) {
+				foundWarning = true
+			}
+		}
+		assert.True(t, foundWarning, "Should warn about ignored terragrunt queue flags")
+		for _, entry := range hook.Entries {
+			assert.NotEqual(t, logger.FatalLevel, entry.Level,
+				"Should not produce a fatal log entry for --filter combined with --parallel")
+		}
+		assert.True(t, parallelState.ExecuteCalled, "Should still proceed to parallel execution")
+	})
+
+	t.Run(
+		"should warn when --queue-exclude-dir is used with --parallel",
+		func(t *testing.T) {
+			// GIVEN: A terra-managed parallel command that also passes --queue-exclude-dir
+			hook, cleanup := setupFatalInterceptor()
+			defer cleanup()
+
+			parallelState := &commanddoubles.StubParallelState{}
+			cmd := commands.NewRunFromRootCommand(
+				entitybuilders.NewSettingsBuilder().
+					WithTerraModuleCacheDir("/tmp/terra-test-modules").
+					WithTerraProviderCacheDir("/tmp/terra-test-providers").
+					BuildSettings(),
+				&commanddoubles.StubInstallDependencies{},
+				&commanddoubles.StubFormatFiles{},
+				&commanddoubles.StubRunAdditionalBefore{},
+				parallelState,
+				&repositorydoubles.StubShellRepositoryForRoot{},
+				&repositorydoubles.StubUpgradeShellRepository{},
+				&repositorydoubles.StubInteractiveShellRepository{},
+			)
+			arguments := []string{"plan", "--parallel=3", "--queue-exclude-dir=foo"}
+			dependencies := []entities.Dependency{}
+
+			// WHEN: Executing the command
+			cmd.Execute("/test/path", arguments, dependencies)
+
+			// THEN: Should log a warning and still proceed
+			var foundWarning bool
+			for _, entry := range hook.Entries {
+				if entry.Level == logger.WarnLevel &&
+					strings.Contains(
+						entry.Message,
+						"--filter, --queue-exclude-dir, and --queue-include-dir are terragrunt flags",
+					) {
+					foundWarning = true
+				}
+			}
+			assert.True(t, foundWarning, "Should warn about ignored terragrunt queue flags")
+			assert.True(
+				t,
+				parallelState.ExecuteCalled,
+				"Should still proceed to parallel execution",
+			)
+		},
+	)
+
+	t.Run("should not warn when --filter is used with --all", func(t *testing.T) {
+		// GIVEN: Arguments combining --all with terragrunt's own --filter flag (valid)
+		hook, cleanup := setupFatalInterceptor()
+		defer cleanup()
+
+		upgradeRepository := &repositorydoubles.StubUpgradeShellRepository{}
+		cmd := commands.NewRunFromRootCommand(
+			entitybuilders.NewSettingsBuilder().
+				WithTerraModuleCacheDir("/tmp/terra-test-modules").
+				WithTerraProviderCacheDir("/tmp/terra-test-providers").
+				BuildSettings(),
+			&commanddoubles.StubInstallDependencies{},
+			&commanddoubles.StubFormatFiles{},
+			&commanddoubles.StubRunAdditionalBefore{},
+			&commanddoubles.StubParallelState{},
+			&repositorydoubles.StubShellRepositoryForRoot{},
+			upgradeRepository,
+			&repositorydoubles.StubInteractiveShellRepository{},
+		)
+		arguments := []string{"plan", "--all", "--filter=foo"}
+		dependencies := []entities.Dependency{}
+
+		// WHEN: Executing the command
+		cmd.Execute("/test/path", arguments, dependencies)
+
+		// THEN: Should not log any warning about the terragrunt flags being ignored
+		for _, entry := range hook.Entries {
+			if entry.Level == logger.WarnLevel {
+				assert.NotContains(
+					t,
+					entry.Message,
+					"terragrunt flags and have no effect with --parallel",
+					"Should not warn about terragrunt flags when combined with --all",
+				)
+			}
+		}
+		assert.Equal(t, 1, upgradeRepository.ExecuteCallCount,
+			"Should proceed to normal (forwarded) execution")
 	})
 }
 

--- a/internal/domain/commands/state_utils.go
+++ b/internal/domain/commands/state_utils.go
@@ -23,6 +23,16 @@ const (
 	DeprecatedIncludeFlagPrefix = "--include="
 	// DeprecatedExcludeFlagPrefix is the renamed --exclude flag (now --skip).
 	DeprecatedExcludeFlagPrefix = "--exclude="
+
+	// FilterFlagPrefix represents the prefix for terragrunt's --filter flag.
+	// Forwarded to terragrunt as-is; only meaningful with --all.
+	FilterFlagPrefix = "--filter="
+	// QueueExcludeDirFlag represents terragrunt's --queue-exclude-dir flag.
+	// Forwarded to terragrunt as-is; only meaningful with --all.
+	QueueExcludeDirFlag = "--queue-exclude-dir"
+	// QueueIncludeDirFlag represents terragrunt's --queue-include-dir flag.
+	// Forwarded to terragrunt as-is; only meaningful with --all.
+	QueueIncludeDirFlag = "--queue-include-dir"
 )
 
 // IsStateManipulationCommand checks if the given arguments represent a state manipulation command.
@@ -115,6 +125,49 @@ func HasDeprecatedNoParallelBypassFlag(arguments []string) bool {
 // HasDeprecatedIncludeFlag checks if the renamed --include= flag is present.
 func HasDeprecatedIncludeFlag(arguments []string) bool {
 	return hasFlagWithPrefix(arguments, DeprecatedIncludeFlagPrefix)
+}
+
+// HasFilterFlag checks if terragrunt's --filter flag is present (either --filter=<query>
+// or the space form --filter <query>). Used only by validation to warn when terragrunt
+// queue flags are combined with terra's --parallel=N (where they have no effect).
+func HasFilterFlag(arguments []string) bool {
+	for i, arg := range arguments {
+		if strings.HasPrefix(arg, FilterFlagPrefix) {
+			return true
+		}
+		if arg == "--filter" && i+1 < len(arguments) {
+			return true
+		}
+	}
+	return false
+}
+
+// HasQueueExcludeDirFlag checks if terragrunt's --queue-exclude-dir flag is present
+// (either --queue-exclude-dir=<dir> or the space form --queue-exclude-dir <dir>).
+func HasQueueExcludeDirFlag(arguments []string) bool {
+	for i, arg := range arguments {
+		if strings.HasPrefix(arg, QueueExcludeDirFlag+"=") {
+			return true
+		}
+		if arg == QueueExcludeDirFlag && i+1 < len(arguments) {
+			return true
+		}
+	}
+	return false
+}
+
+// HasQueueIncludeDirFlag checks if terragrunt's --queue-include-dir flag is present
+// (either --queue-include-dir=<dir> or the space form --queue-include-dir <dir>).
+func HasQueueIncludeDirFlag(arguments []string) bool {
+	for i, arg := range arguments {
+		if strings.HasPrefix(arg, QueueIncludeDirFlag+"=") {
+			return true
+		}
+		if arg == QueueIncludeDirFlag && i+1 < len(arguments) {
+			return true
+		}
+	}
+	return false
 }
 
 // HasDeprecatedExcludeFlag checks if the renamed --exclude= flag is present.

--- a/internal/infrastructure/controllers/run_from_root_controller.go
+++ b/internal/infrastructure/controllers/run_from_root_controller.go
@@ -34,7 +34,9 @@ func (it *RunFromRootController) GetBind() entities.ControllerBind {
 			"\n" +
 			"  --parallel=N   Terra-managed worker pool. Supports --only=mod1,mod2 and\n" +
 			"                 --skip=mod1,mod2 for basename-matched module selection.\n" +
-			"                 Required for state operations (import, state rm, state mv).\n" +
+			"                 Required for Terra-managed multi-module state operations\n" +
+			"                 from the root (import, state rm, state mv); single-module\n" +
+			"                 state commands can run without --parallel.\n" +
 			"\n" +
 			"  --all          Terragrunt-managed run-all. Uses terragrunt's DAG. Filter\n" +
 			"                 with --filter='!mod' (recommended; supports globs, graph,\n" +

--- a/internal/infrastructure/controllers/run_from_root_controller.go
+++ b/internal/infrastructure/controllers/run_from_root_controller.go
@@ -26,8 +26,21 @@ func (it *RunFromRootController) GetBind() entities.ControllerBind {
 	return entities.ControllerBind{
 		Use:   "terra [flags] [terragrunt command] [directory]",
 		Short: "Terra is a CLI wrapper for Terragrunt",
-		Long: "Terra is a CLI wrapper for Terragrunt that allows changing directory before executing commands. " +
-			"It also allows changing the account/subscription and workspace for AWS and Azure.",
+		Long: "Terra is a CLI wrapper for Terragrunt that allows changing directory before " +
+			"executing commands. It also switches the account/subscription and workspace for " +
+			"AWS and Azure automatically based on the .env configuration.\n" +
+			"\n" +
+			"Parallel execution strategies:\n" +
+			"\n" +
+			"  --parallel=N   Terra-managed worker pool. Supports --only=mod1,mod2 and\n" +
+			"                 --skip=mod1,mod2 for basename-matched module selection.\n" +
+			"                 Required for state operations (import, state rm, state mv).\n" +
+			"\n" +
+			"  --all          Terragrunt-managed run-all. Uses terragrunt's DAG. Filter\n" +
+			"                 with --filter='!mod' (recommended; supports globs, graph,\n" +
+			"                 and git-diff expressions) or --queue-exclude-dir=mod.\n" +
+			"\n" +
+			"These two strategies cannot be combined. See docs/parallel-execution.md.",
 	}
 }
 

--- a/internal/infrastructure/controllers/run_from_root_controller_test.go
+++ b/internal/infrastructure/controllers/run_from_root_controller_test.go
@@ -50,14 +50,16 @@ func TestRunFromRootController_GetBind(t *testing.T) {
 		// WHEN: Getting the controller bind
 		bind := controller.GetBind()
 
-		// THEN: Should return correct bind configuration
+		// THEN: Should return correct bind configuration with the two parallel
+		// strategies clearly documented in the Long text
 		assert.Equal(t, "terra [flags] [terragrunt command] [directory]", bind.Use)
 		assert.Equal(t, "Terra is a CLI wrapper for Terragrunt", bind.Short)
-		assert.Equal(
-			t,
-			"Terra is a CLI wrapper for Terragrunt that allows changing directory before executing commands. It also allows changing the account/subscription and workspace for AWS and Azure.",
-			bind.Long,
-		)
+		assert.Contains(t, bind.Long, "Terra is a CLI wrapper for Terragrunt")
+		assert.Contains(t, bind.Long, "Parallel execution strategies:")
+		assert.Contains(t, bind.Long, "--parallel=N")
+		assert.Contains(t, bind.Long, "--all")
+		assert.Contains(t, bind.Long, "--filter='!mod'")
+		assert.Contains(t, bind.Long, "docs/parallel-execution.md")
 	})
 }
 


### PR DESCRIPTION
## Summary

- Rewrites the `--only`/`--skip` and `--parallel` + `--all` validation errors into multi-line, copy-pasteable messages that echo the user's command and show both valid alternative forms (`--parallel=5 --skip=mod` **and** `--all --filter='!mod'`).
- Adds a non-fatal warning when terragrunt-only flags (`--filter`, `--queue-exclude-dir`, `--queue-include-dir`) are combined with `--parallel=N`, since terra's worker pool silently ignores them — previously a latent source of confusion.
- Expands `terra --help` with a "Parallel execution strategies" block so users discover the split without reading the docs.
- Updates README, `docs/parallel-execution.md`, `CLAUDE.md`, and `.github/copilot-instructions.md` with a "Choosing a strategy" checklist, a filter-equivalence table, and a "Known differences" section citing [gruntwork-io/terragrunt#5124](https://github.com/gruntwork-io/terragrunt/issues/5124) as the reason terra does **not** translate between the two strategies.

## Why this change

A user in CI ran `terra apply --all --skip=1051-lab3 environments/...`, hit the terse `Error: --only/--skip flags require --parallel=N`, and fell back to manually typing `terragrunt apply --all --queue-exclude-dir 1051-lab3 …` which they called "big and weird." The root cause is a discoverability failure: terra owns `--only`/`--skip` for the `--parallel=N` path, terragrunt owns `--filter`/`--queue-exclude-dir` for the `--all` path, and the error told users to use one path without teaching them the equivalent on the other.

## Why not unify the flags

I researched this thoroughly before committing to the direction. Translating `--skip=a` into `--queue-exclude-dir=a` or `--filter='!a'` is the wrong fix:

1. **Matching semantics differ.** Terra's `--skip=lab3` matches by basename anywhere in the subtree. Terragrunt's `--queue-exclude-dir=lab3` matches paths relative to CWD with terragrunt-specific glob rules. Any translation lies about semantics or re-implements terragrunt's walker.
2. **Upstream parsing quirks.** terragrunt issue #5124 shows that `--queue-exclude-dir` still parses excluded directories during dependency discovery. Terra's native `--skip` doesn't. Silent translation would cause subtle CI incidents.
3. **`--filter` is strictly more expressive.** Translating `--skip=a,b` to `--queue-exclude-dir` would downgrade capability for `--all` users who have access to graph and git-diff expressions.
4. **Commit `a0af9d1` explicitly removed this kind of translation.** Reintroducing it regresses a deliberate architectural decision.

Instead, this PR fixes the **discoverability** problem: every validation error now teaches users both paths by example.

## Before

```
$ terra apply --all --skip=1051-lab3 environments/05_dfir_iris/dev
Error: --only/--skip flags require --parallel=N.
```

## After

```
$ terra apply --all --skip=1051-lab3 environments/05_dfir_iris/dev
Error: --only/--skip are terra-managed flags and require --parallel=N.
You used: terra apply --all --skip=1051-lab3 environments/05_dfir_iris/dev

Terra has two separate parallel-execution strategies. --only/--skip only work with the first:

  1) Terra-managed worker pool (simple basename matching across the tree):
       terra apply --parallel=5 --skip=1051-lab3 --reply environments/05_dfir_iris/dev

  2) Terragrunt-managed run-all (DAG-aware; supports path globs, graph and git-diff expressions):
       terra apply --all --filter='!1051-lab3' environments/05_dfir_iris/dev

Terragrunt's --filter is strictly more expressive than terra's --skip/--only.
See docs/parallel-execution.md for the full comparison.
```

The suggestions are copy-pasteable with the user's own values already substituted — `--reply` is appended only for interactive commands (`apply`/`destroy`), skip values are negated with `!` for the filter form, and target paths are preserved on both lines.

## Test plan

- [x] `go test -tags unit ./...` — all pass (new `TestBuildSelectionFlagsError`, `TestBuildParallelAllConflictError`, `TestRunFromRootCommand_warnWhenTerragruntQueueFlagsUsedWithParallel`, plus updates to existing assertions)
- [x] `go test -tags integration ./internal/domain/commands/...` — all pass
- [x] `make lint` — 0 issues
- [x] `make build` — binary built
- [x] Manual smoke test: `terra apply --all --skip=1051-lab3 /tmp/x` prints the new educational error with the user's own argv echoed
- [x] Manual smoke test: `terra plan --parallel=3 --filter=foo /tmp/x` logs the new symmetric warning and continues
- [x] Manual smoke test: `terra plan --parallel=5 --all /tmp/x` prints the conflict error with both alternatives
- [x] Manual smoke test: `terra --help` shows the "Parallel execution strategies" block
- [x] Regression: `--only` + `--skip` overlap detection still fatals
- [x] Regression: `--reply` validation for `--parallel` apply/destroy and `--all` with explicit value unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)