### PR TITLE
feat(confirmation): add --yes/-y and --no/-n, deprecate --reply/-r

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,22 @@ Exceptions are acceptable depending on the circumstances (critical bug fixes tha
 
 ## [Unreleased]
 
+### Added
+
+- added `--yes` / `-y` and `--no` / `-n` confirmation flags that translate to native Terraform and Terragrunt flags. `--yes` injects Terragrunt's `--non-interactive` plus Terraform's `-auto-approve` for `apply` / `destroy`; `--no` injects only `--non-interactive`, so Terraform's apply prompt aborts instead of proceeding. This aligns terra with the `apt` / `npm` / `az` convention and replaces the previous PTY-based approach with reliable flag injection.
+
+### Changed
+
+- changed the validation error for `--parallel` with `apply` / `destroy` from "`--reply` is required" to "`--yes` is required", matching the new flag names in error messages and copy-pasteable suggestions.
+
+### Deprecated
+
+- deprecated the `--reply` / `-r` flags. They still work and are translated to the new `--yes` / `--no` flag injection (`--reply=y` and bare `--reply` map to `--yes`; `--reply=n` maps to `--no`), but now emit a one-time migration warning. `--reply` will be removed in a future release.
+
+### Fixed
+
+- fixed `terra apply --reply=y` silently waiting forever on Terraform's "Do you want to perform these actions? Enter a value:" prompt. The previous PTY-based auto-responder only matched `[y/n]` and "external dependency" prompts, so Terraform's apply confirmation (which requires the literal word `yes`) was never answered. Users had to fall back to `-auto-approve`. The new flag-injection path invokes `-auto-approve` natively, so `terra apply --yes` (and the deprecated `--reply=y`) now work reliably.
+
 ## [1.14.3] - 2026-04-20
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ A powerful wrapper for Terragrunt and Terraform that revolutionizes infrastructu
 - Enhanced state management
 - Simplified module path specification
 - Cross-platform compatibility
-- Auto-replying to Terragrunt prompts via `--reply` / `-r` to avoid manual intervention
+- Non-interactive execution via `--yes` / `-y` (or `--no` / `-n`) that maps to Terraform's `-auto-approve` and Terragrunt's `--non-interactive` -- no PTY pattern matching, works reliably with `terraform apply`
 - Self-update capability to automatically update terra to the latest version
 - Version checking for Terra, Terraform, and Terragrunt dependencies
 - Automatic dependency installation and management
@@ -103,13 +103,13 @@ terra plan --all /path/to/module
 # or using Terraform approach, plan just the "module" subdirectory inside "to"
 terra plan /path/to/module
 
-# with auto-replying "y" to avoid manual prompts
-terra --reply=y apply --all /path
-terra -r=y plan --all /path/to
+# skip all confirmation prompts (apply/destroy use Terraform's -auto-approve)
+terra apply --yes --all /path
+terra -y plan --all /path/to
 
-# with auto-replying "n" to reject prompts
-terra --reply=n apply --all /path
-terra -r=n plan --all /path/to
+# run non-interactively and abort on any confirmation prompt (no auto-approve)
+terra apply --no --all /path
+terra -n plan --all /path/to
 ```
 
 ### Command Reference
@@ -123,35 +123,48 @@ self-update Update terra to the latest version
 version     Show Terra, Terraform, and Terragrunt versions
 ```
 
-### Reply Feature
+### Confirmation Flags: `--yes` and `--no`
 
-The `--reply` (or `-r`) flag enables automatic responses to Terragrunt prompts, eliminating the need for manual intervention during long-running operations. This is particularly useful in CI/CD pipelines or when running multiple Terragrunt commands.
+Terra translates two terra-level confirmation flags into native Terraform and Terragrunt flags so CI/CD pipelines and parallel workers never get stuck on prompts:
 
-**What it does:**
-- Automatically answers "n" to external dependency prompts (when using boolean flag or explicit `--reply=n`)
-- Automatically answers "y" to external dependency prompts (when using `--reply=y`)
-- Automatically answers general yes/no prompts with the specified value
-- Switches to manual mode for confirmation prompts (like "Are you sure you want to run...")
-- Filters out the reply flag before passing arguments to Terragrunt
+| Flag | Short | Injected into the forwarded command |
+|------|-------|-------------------------------------|
+| `--yes` | `-y` | Terragrunt's `--non-interactive` + Terraform's `-auto-approve` (for `apply` / `destroy`) |
+| `--no` | `-n` | Terragrunt's `--non-interactive` only (Terraform's apply prompt aborts instead of proceeding, matching a "no" answer) |
 
-**Usage with `--all` (terragrunt-managed parallelism):** requires an explicit value (`--reply=y` or `--reply=n`) because the PTY auto-answering needs to know how to respond.
+No PTY, no regex-based prompt detection. The translation happens before the command is forwarded to Terragrunt, so the behavior is reliable across Terraform and Terragrunt versions.
 
 ```bash
-# With explicit "y" answer - automatically answers "y" to prompts
-terra --reply=y apply --all /path
+# Non-interactive apply across a stack (Terraform's -auto-approve is injected automatically)
+terra apply --yes /path
+terra -y apply --all /path
+terra apply --parallel=4 --yes /path
 
-# Short form syntax
-terra -r=y apply --all /path
-terra -r=n plan --all /path
+# Non-interactive execution that aborts on any confirmation prompt
+terra plan --no --all /path
+terra apply --parallel=4 --no /path
 ```
 
-**Usage with `--parallel` (terra-managed parallelism):** just `--reply` (no value) is sufficient. Terra always injects `--non-interactive` when `--reply` is present, and adds `-auto-approve` automatically for interactive commands like `apply` and `destroy`; the reply value is ignored in this mode.
+**When using `--parallel` with `apply` / `destroy`**, a confirmation flag is required because parallel workers cannot share stdin:
 
 ```bash
-# Just --reply is enough for terra-managed parallel
-terra apply --parallel=4 --reply /path
-terra destroy --parallel=4 -r /path
+# ERROR: parallel workers cannot prompt
+terra apply --parallel=4 /path
+
+# CORRECT: inject native non-interactive flags
+terra apply --parallel=4 --yes /path
 ```
+
+#### Deprecated: `--reply` / `-r`
+
+The legacy `--reply` and `-r` flags still work but emit a deprecation warning. They are translated to the same native flags as their `--yes` / `--no` equivalents:
+
+| Legacy form | Mapped to |
+|-------------|-----------|
+| `--reply=y`, `-r=y`, bare `--reply`, bare `-r` | `--yes` |
+| `--reply=n`, `-r=n` | `--no` |
+
+Migrate scripts at your earliest convenience; `--reply` will be removed in a future release.
 
 ### Parallel Execution
 

--- a/docs/parallel-execution.md
+++ b/docs/parallel-execution.md
@@ -148,25 +148,31 @@ Terra deliberately does **not** translate `--skip`/`--only` into `--queue-exclud
 
 Instead, terra provides **discoverability**: when you use `--skip` with `--all`, the validation error echoes your command and shows the exact `--filter` form you should type. When you use terragrunt's `--filter`/`--queue-exclude-dir` with `--parallel=N`, terra logs a warning pointing you at `--only`/`--skip`.
 
-## Interactive Commands Require `--reply`
+## Interactive Commands Require `--yes` (or `--no`)
 
-When using `--parallel` with `apply` or `destroy`, you **must** provide `--reply` because parallel workers cannot share a single stdin for interactive prompts. In this mode, Terra automatically injects `--non-interactive` for each worker, and also adds `-auto-approve` for interactive commands like `apply` and `destroy`, so **just `--reply` without a value is sufficient** -- the value is ignored in terra-managed parallel mode.
+When using `--parallel` with `apply` or `destroy`, you **must** provide a confirmation flag because parallel workers cannot share a single stdin for interactive prompts. Terra translates these flags into native Terraform and Terragrunt flags before forwarding the command, so there is no PTY pattern matching involved:
+
+- `--yes` / `-y` injects Terragrunt's `--non-interactive` plus Terraform's `-auto-approve` for `apply` / `destroy`.
+- `--no` / `-n` injects only Terragrunt's `--non-interactive`, which causes Terraform's apply prompt to abort instead of proceeding -- matching a "no" answer.
 
 ```bash
 # ERROR: apply prompts for confirmation, but parallel workers can't share stdin
 terra apply --parallel=4 /path/to/infrastructure
 
-# CORRECT: just --reply (no value needed) is enough for terra-managed parallel
-terra apply --parallel=4 --reply /path/to/infrastructure
+# CORRECT: --yes maps to --non-interactive -auto-approve
+terra apply --parallel=4 --yes /path/to/infrastructure
 
 # Short form
-terra destroy --parallel=4 -r /path/to/infrastructure
+terra destroy --parallel=4 -y /path/to/infrastructure
 
-# OK: plan never prompts, so --reply is not required
+# Non-interactive, but abort instead of auto-approving
+terra apply --parallel=4 --no /path/to/infrastructure
+
+# OK: plan never prompts, so no confirmation flag is required
 terra plan --parallel=4 /path/to/infrastructure
 ```
 
-> **Note:** The `--reply` value (e.g., `--reply=y`) is only meaningful with `--all` (terragrunt-managed parallelism), where the PTY uses it to auto-answer prompts. With `--parallel`, the value is ignored and a warning is shown if provided.
+> **Note:** The legacy `--reply` / `-r` flags still work and emit a deprecation warning. `--reply=y` and bare `--reply` map to `--yes`; `--reply=n` maps to `--no`. Migrate to `--yes` / `--no` at your earliest convenience; `--reply` will be removed in a future release.
 
 ## Supported Commands
 

--- a/internal/domain/commands/parallel_state_command.go
+++ b/internal/domain/commands/parallel_state_command.go
@@ -33,11 +33,12 @@ func (it *ParallelStateCommand) shouldExecuteInParallel(arguments []string) bool
 	return HasParallelFlag(arguments)
 }
 
-// removeParallelFlags removes --parallel=N, --only=, --skip=, and --reply/-r flags from arguments.
+// removeParallelFlags removes terra-managed flags (--parallel=N, --only=, --skip=)
+// and all confirmation flags (--yes/-y, --no/-n, --reply/-r) from arguments.
 func (it *ParallelStateCommand) removeParallelFlags(arguments []string) []string {
 	filtered := RemoveParallelFlag(arguments)
 	filtered = RemoveSelectionFlags(filtered)
-	return RemoveReplyFlag(filtered)
+	return RemoveConfirmationFlags(filtered)
 }
 
 // findSubdirectories finds all subdirectories that contain terraform/terragrunt files.
@@ -286,19 +287,9 @@ func (it *ParallelStateCommand) executeInParallel(
 		logger.Infof("Reducing thread count to %d (number of modules)", maxJobs)
 	}
 
-	hadReplyFlag := HasReplyFlag(arguments)
+	injected := BuildConfirmationInjection(arguments)
 	filteredArguments := it.removeParallelFlags(arguments)
-
-	// When --reply was provided, inject flags so workers don't prompt:
-	// --non-interactive: tells terragrunt to skip its own prompts (e.g., "run-all" confirmations)
-	// -auto-approve: tells terraform to skip the "Do you want to perform these actions?" confirmation
-	//                (TF_INPUT=false from --non-interactive only suppresses variable input, not apply confirmation)
-	if hadReplyFlag {
-		filteredArguments = append(filteredArguments, "--non-interactive")
-		if IsInteractiveCommand(arguments) {
-			filteredArguments = append(filteredArguments, "-auto-approve")
-		}
-	}
+	filteredArguments = append(filteredArguments, injected...)
 
 	executeErrors := it.runWorkers(modules, filteredArguments, maxJobs)
 	duration := time.Since(startTime)

--- a/internal/domain/commands/parallel_state_command_test.go
+++ b/internal/domain/commands/parallel_state_command_test.go
@@ -452,8 +452,8 @@ func TestParallelStateCommand_Execute(t *testing.T) {
 		assert.NotContains(t, lastCall.Arguments, "-auto-approve", "Should not inject -auto-approve for plan")
 	})
 
-	t.Run("should not inject --non-interactive when reply not present", func(t *testing.T) {
-		// GIVEN: A parallel state command without --reply flag
+	t.Run("should not inject --non-interactive when no confirmation flag present", func(t *testing.T) {
+		// GIVEN: A parallel state command without any confirmation flag
 		repository := &repositorydoubles.StubShellRepositoryForParallelState{}
 		cmd := commands.NewParallelStateCommand(repository)
 		arguments := []string{"plan", "--parallel=2"}
@@ -470,7 +470,59 @@ func TestParallelStateCommand_Execute(t *testing.T) {
 		require.NoError(t, err)
 		require.NotEmpty(t, repository.CallHistory)
 		lastCall := repository.CallHistory[len(repository.CallHistory)-1]
-		assert.NotContains(t, lastCall.Arguments, "--non-interactive", "Should not inject --non-interactive without --reply")
+		assert.NotContains(t, lastCall.Arguments, "--non-interactive", "Should not inject --non-interactive without a confirmation flag")
+	})
+
+	t.Run("should strip --yes and inject --non-interactive and -auto-approve for apply", func(t *testing.T) {
+		// GIVEN: A parallel state command with the new --yes flag on apply
+		repository := &repositorydoubles.StubShellRepositoryForParallelState{}
+		cmd := commands.NewParallelStateCommand(repository)
+		arguments := []string{"apply", "--parallel=2", "--yes"}
+		dependencies := []entities.Dependency{}
+
+		tempDir := t.TempDir()
+		testHelper := newTestDirectoryHelper(t)
+		testHelper.createModuleDirectories(tempDir, []string{"mod1"})
+
+		// WHEN: Executing the command
+		err := cmd.Execute(tempDir, arguments, dependencies)
+
+		// THEN: Should strip --yes and inject both native flags
+		require.NoError(t, err)
+		require.NotEmpty(t, repository.CallHistory)
+		lastCall := repository.CallHistory[len(repository.CallHistory)-1]
+		for _, arg := range lastCall.Arguments {
+			assert.NotEqual(t, "--yes", arg, "Should not pass --yes flag to terragrunt")
+			assert.NotEqual(t, "-y", arg, "Should not pass -y flag to terragrunt")
+		}
+		assert.Contains(t, lastCall.Arguments, "--non-interactive")
+		assert.Contains(t, lastCall.Arguments, "-auto-approve")
+	})
+
+	t.Run("should strip --no and inject only --non-interactive", func(t *testing.T) {
+		// GIVEN: A parallel state command with the new --no flag on apply
+		repository := &repositorydoubles.StubShellRepositoryForParallelState{}
+		cmd := commands.NewParallelStateCommand(repository)
+		arguments := []string{"apply", "--parallel=2", "--no"}
+		dependencies := []entities.Dependency{}
+
+		tempDir := t.TempDir()
+		testHelper := newTestDirectoryHelper(t)
+		testHelper.createModuleDirectories(tempDir, []string{"mod1"})
+
+		// WHEN: Executing the command
+		err := cmd.Execute(tempDir, arguments, dependencies)
+
+		// THEN: Should strip --no and inject only --non-interactive (no -auto-approve)
+		require.NoError(t, err)
+		require.NotEmpty(t, repository.CallHistory)
+		lastCall := repository.CallHistory[len(repository.CallHistory)-1]
+		for _, arg := range lastCall.Arguments {
+			assert.NotEqual(t, "--no", arg, "Should not pass --no flag to terragrunt")
+			assert.NotEqual(t, "-n", arg, "Should not pass -n flag to terragrunt")
+		}
+		assert.Contains(t, lastCall.Arguments, "--non-interactive")
+		assert.NotContains(t, lastCall.Arguments, "-auto-approve", "Should not inject -auto-approve for --no")
 	})
 }
 

--- a/internal/domain/commands/run_from_root_command.go
+++ b/internal/domain/commands/run_from_root_command.go
@@ -85,26 +85,40 @@ func (it *RunFromRootCommand) Execute(
 	// Normal execution path for non-parallel commands
 	it.additionalBefore.Execute(targetPath, arguments)
 
-	// Check if reply flag is present and filter it out
-	useInteractive := it.hasReplyFlag(arguments)
-	replyValue := it.getReplyValue(arguments)
-	filteredArguments := it.removeReplyFlag(arguments)
+	// Translate terra confirmation flags (--yes/-y, --no/-n, legacy --reply/-r)
+	// into native Terraform/Terragrunt flags, then strip the terra-level flags.
+	it.warnDeprecatedReplyFlag(arguments)
+	injected := BuildConfirmationInjection(arguments)
+	filteredArguments := RemoveConfirmationFlags(arguments)
+	filteredArguments = append(filteredArguments, injected...)
 
-	var err error
-	if useInteractive {
-		logger.Infof("Using interactive mode with auto-replying (%s)", replyValue)
-		err = it.interactiveRepository.ExecuteCommandWithAnswer(
-			"terragrunt", filteredArguments, targetPath, replyValue)
-	} else {
-		// Use upgrade-aware repository: automatically detects when init --upgrade
-		// is needed, runs it, and retries the original command.
-		err = it.upgradeRepository.ExecuteCommandWithUpgrade(
-			"terragrunt", filteredArguments, targetPath)
-	}
-
+	// Use upgrade-aware repository: automatically detects when init --upgrade
+	// is needed, runs it, and retries the original command.
+	err := it.upgradeRepository.ExecuteCommandWithUpgrade(
+		"terragrunt", filteredArguments, targetPath)
 	if err != nil {
 		logger.Fatalf("Terragrunt command failed: %s", err)
 	}
+}
+
+// warnDeprecatedReplyFlag emits a one-time migration warning when --reply/-r is used.
+// The flag keeps working (mapped via BuildConfirmationInjection), but users should
+// migrate to --yes/-y or --no/-n.
+func (it *RunFromRootCommand) warnDeprecatedReplyFlag(arguments []string) {
+	if !HasReplyFlag(arguments) {
+		return
+	}
+	yes, _ := ResolveConfirmation(arguments)
+	replacement := NoFlag
+	if yes {
+		replacement = YesFlag
+	}
+	logger.Warnf(
+		"--reply/-r is deprecated and will be removed in a future release. "+
+			"Use %s instead. It maps to Terraform's -auto-approve and Terragrunt's "+
+			"--non-interactive, which reliably skips prompts without PTY pattern matching.",
+		replacement,
+	)
 }
 
 func (it *RunFromRootCommand) hasReplyFlag(arguments []string) bool {
@@ -132,24 +146,13 @@ func (it *RunFromRootCommand) validateFlagCombinations(arguments []string, targe
 		logger.Fatalf("%s", BuildParallelAllConflictError(arguments, targetPath))
 	}
 
-	// --reply is required when --parallel is used with interactive commands (apply, destroy)
-	// because parallel workers cannot handle stdin prompts
-	if hasParallelFlag && IsInteractiveCommand(arguments) && !HasReplyFlag(arguments) {
+	// A confirmation flag (--yes/-y, --no/-n, or the deprecated --reply/-r) is
+	// required when --parallel is used with interactive commands (apply, destroy)
+	// because parallel workers cannot share stdin for prompts.
+	if hasParallelFlag && IsInteractiveCommand(arguments) && !HasConfirmationFlag(arguments) {
 		logger.Fatalf(
-			"Error: --reply is required when using --parallel with apply or destroy. " +
-				"Parallel workers cannot handle interactive prompts. Example: --reply",
-		)
-	}
-
-	// Warn when --reply has an explicit value with --parallel: the value is ignored
-	// for terra-managed parallel execution. The value is only meaningful with
-	// --all (terragrunt-managed parallelism) where the PTY uses it.
-	if hasParallelFlag && HasExplicitReplyValue(arguments) {
-		logger.Warnf(
-			"The --reply value is ignored for terra-managed parallel execution (--parallel). " +
-				"It is only used with --all for terragrunt-managed parallelism, where the PTY " +
-				"uses the value to answer prompts. Just --reply without a value is sufficient " +
-				"when using --parallel.",
+			"Error: --yes is required when using --parallel with apply or destroy. " +
+				"Parallel workers cannot share stdin for prompts. Example: --yes (or -y).",
 		)
 	}
 
@@ -162,16 +165,6 @@ func (it *RunFromRootCommand) validateFlagCombinations(arguments []string, targe
 				"and have no effect with --parallel=N (terra-managed parallelism). " +
 				"Use --only=mod1,mod2 or --skip=mod1,mod2 for module selection, " +
 				"or switch to --all to let terragrunt handle filtering natively.",
-		)
-	}
-
-	// --reply requires an explicit value when used with --all (terragrunt-managed parallelism)
-	// because the PTY auto-answering needs to know whether to respond "y" or "n".
-	if hasAllFlag && HasReplyFlag(arguments) && !HasExplicitReplyValue(arguments) {
-		logger.Fatalf(
-			"Error: --reply requires an explicit value when used with --all " +
-				"(e.g., --reply=y or --reply=n). The value is used to auto-answer " +
-				"terragrunt prompts in terragrunt-managed parallelism.",
 		)
 	}
 
@@ -194,17 +187,17 @@ func (it *RunFromRootCommand) validateDeprecatedFlags(arguments []string) {
 		if arg == DeprecatedAutoAnswerShortFlag || strings.HasPrefix(arg, DeprecatedAutoAnswerShortFlag+"=") {
 			logger.Fatalf(
 				"Error: the -a short flag has been removed (conflicts with terragrunt's -a for --all). " +
-					"Use --reply or -r instead. Example: --reply=y",
+					"Use --yes or -y instead.",
 			)
 		}
 	}
 
-	// Detect --auto-answer (renamed to --reply)
+	// Detect --auto-answer (renamed to --yes)
 	for _, arg := range arguments {
 		if arg == DeprecatedAutoAnswerFlag || strings.HasPrefix(arg, DeprecatedAutoAnswerFlag+"=") {
 			logger.Fatalf(
-				"Error: --auto-answer has been renamed to --reply. " +
-					"Use --reply or -r instead. Example: --reply=y",
+				"Error: --auto-answer has been replaced by --yes. " +
+					"Use --yes or -y instead.",
 			)
 		}
 	}

--- a/internal/domain/commands/run_from_root_command.go
+++ b/internal/domain/commands/run_from_root_command.go
@@ -112,14 +112,15 @@ func (it *RunFromRootCommand) warnDeprecatedReplyFlag(arguments []string) {
 	}
 	yes, _ := ResolveConfirmation(arguments)
 	replacement := NoFlag
+	injection := "Terragrunt's --non-interactive (so the Terraform apply prompt aborts instead of proceeding)"
 	if yes {
 		replacement = YesFlag
+		injection = "Terragrunt's --non-interactive plus Terraform's -auto-approve for apply/destroy"
 	}
 	logger.Warnf(
 		"--reply/-r is deprecated and will be removed in a future release. "+
-			"Use %s instead. It maps to Terraform's -auto-approve and Terragrunt's "+
-			"--non-interactive, which reliably skips prompts without PTY pattern matching.",
-		replacement,
+			"Use %s instead. It maps to %s, which reliably skips prompts without PTY pattern matching.",
+		replacement, injection,
 	)
 }
 

--- a/internal/domain/commands/run_from_root_command.go
+++ b/internal/domain/commands/run_from_root_command.go
@@ -101,9 +101,11 @@ func (it *RunFromRootCommand) Execute(
 	}
 }
 
-// warnDeprecatedReplyFlag emits a one-time migration warning when --reply/-r is used.
+// warnDeprecatedReplyFlag emits a migration warning when --reply/-r is used.
 // The flag keeps working (mapped via BuildConfirmationInjection), but users should
-// migrate to --yes/-y or --no/-n.
+// migrate to --yes/-y or --no/-n. Execute runs once per CLI invocation, so this
+// fires at most once per process, but the warning is not deduplicated across
+// repeated Execute calls within the same process (e.g., in tests).
 func (it *RunFromRootCommand) warnDeprecatedReplyFlag(arguments []string) {
 	if !HasReplyFlag(arguments) {
 		return
@@ -151,8 +153,8 @@ func (it *RunFromRootCommand) validateFlagCombinations(arguments []string, targe
 	// because parallel workers cannot share stdin for prompts.
 	if hasParallelFlag && IsInteractiveCommand(arguments) && !HasConfirmationFlag(arguments) {
 		logger.Fatalf(
-			"Error: --yes is required when using --parallel with apply or destroy. " +
-				"Parallel workers cannot share stdin for prompts. Example: --yes (or -y).",
+			"Error: a confirmation flag is required when using --parallel with apply or destroy. " +
+				"Parallel workers cannot share stdin for prompts. Use --yes (or -y), --no (or -n), or --reply (or -r).",
 		)
 	}
 

--- a/internal/domain/commands/run_from_root_command_test.go
+++ b/internal/domain/commands/run_from_root_command_test.go
@@ -245,13 +245,14 @@ func TestRunFromRootCommand_Execute(t *testing.T) {
 		assert.Equal(t, arguments, upgradeRepository.LastArguments, "Should pass arguments unchanged")
 	})
 
-	t.Run("should use interactive mode with default 'n' when boolean reply flag", func(t *testing.T) {
+	t.Run("should inject --non-interactive when boolean --reply maps to yes on plan", func(t *testing.T) {
 		t.Parallel()
-		// GIVEN: A command with boolean reply flag in arguments
+		// GIVEN: A command with the deprecated boolean --reply flag on a non-interactive command
 		installCommand := &commanddoubles.StubInstallDependencies{}
 		formatCommand := &commanddoubles.StubFormatFiles{}
 		additionalBefore := &commanddoubles.StubRunAdditionalBefore{}
 		repository := &repositorydoubles.StubShellRepositoryForRoot{}
+		upgradeRepository := &repositorydoubles.StubUpgradeShellRepository{}
 		interactiveRepository := &repositorydoubles.StubInteractiveShellRepository{}
 		cmd := commands.NewRunFromRootCommand(
 			entitybuilders.NewSettingsBuilder().BuildSettings(),
@@ -260,7 +261,7 @@ func TestRunFromRootCommand_Execute(t *testing.T) {
 			additionalBefore,
 			&commanddoubles.StubParallelState{},
 			repository,
-			&repositorydoubles.StubUpgradeShellRepository{},
+			upgradeRepository,
 			interactiveRepository,
 		)
 
@@ -271,20 +272,26 @@ func TestRunFromRootCommand_Execute(t *testing.T) {
 		// WHEN: Executing the command
 		cmd.Execute(targetPath, arguments, dependencies)
 
-		// THEN: Should use interactive repository with default 'n' answer
-		assert.Equal(t, 1, interactiveRepository.ExecuteWithAnswerCallCount, "Should use interactive repository")
-		assert.Equal(t, []string{"plan", "--detailed-exitcode"}, interactiveRepository.LastArguments, "Should filter out reply flag")
-		assert.Equal(t, "n", interactiveRepository.LastAutoAnswer, "Should default to 'n' for boolean flag")
+		// THEN: Routes through the upgrade repository with --non-interactive injected
+		// (no -auto-approve because plan is not an interactive command).
+		assert.Equal(t, 1, upgradeRepository.ExecuteCallCount, "Should use upgrade repository")
+		assert.Equal(t,
+			[]string{"plan", "--detailed-exitcode", "--non-interactive"},
+			upgradeRepository.LastArguments,
+			"Should strip --reply and append --non-interactive",
+		)
+		assert.Equal(t, 0, interactiveRepository.ExecuteWithAnswerCallCount, "PTY path is no longer used")
 		assert.Equal(t, 0, repository.ExecuteCallCount, "Should not use normal repository")
 	})
 
-	t.Run("should use interactive mode with specified 'y' when reply=y flag", func(t *testing.T) {
+	t.Run("should inject --non-interactive and -auto-approve when --reply=y maps to yes on apply", func(t *testing.T) {
 		t.Parallel()
-		// GIVEN: A command with --reply=y flag in arguments
+		// GIVEN: A command with the deprecated --reply=y flag on apply
 		installCommand := &commanddoubles.StubInstallDependencies{}
 		formatCommand := &commanddoubles.StubFormatFiles{}
 		additionalBefore := &commanddoubles.StubRunAdditionalBefore{}
 		repository := &repositorydoubles.StubShellRepositoryForRoot{}
+		upgradeRepository := &repositorydoubles.StubUpgradeShellRepository{}
 		interactiveRepository := &repositorydoubles.StubInteractiveShellRepository{}
 		cmd := commands.NewRunFromRootCommand(
 			entitybuilders.NewSettingsBuilder().BuildSettings(),
@@ -293,22 +300,103 @@ func TestRunFromRootCommand_Execute(t *testing.T) {
 			additionalBefore,
 			&commanddoubles.StubParallelState{},
 			repository,
-			&repositorydoubles.StubUpgradeShellRepository{},
+			upgradeRepository,
 			interactiveRepository,
 		)
 
 		targetPath := "/test/path"
-		arguments := []string{"--reply=y", "apply", "--auto-approve"}
+		arguments := []string{"--reply=y", "apply"}
 		dependencies := []entities.Dependency{}
 
 		// WHEN: Executing the command
 		cmd.Execute(targetPath, arguments, dependencies)
 
-		// THEN: Should use interactive repository with 'y' answer
-		assert.Equal(t, 1, interactiveRepository.ExecuteWithAnswerCallCount, "Should use interactive repository")
-		assert.Equal(t, []string{"apply", "--auto-approve"}, interactiveRepository.LastArguments, "Should filter out reply flag")
-		assert.Equal(t, "y", interactiveRepository.LastAutoAnswer, "Should use specified 'y' value")
+		// THEN: Routes through the upgrade repository with --non-interactive AND
+		// -auto-approve injected (terraform apply needs -auto-approve to skip its
+		// "Enter a value:" prompt; --non-interactive alone does not cover that).
+		assert.Equal(t, 1, upgradeRepository.ExecuteCallCount, "Should use upgrade repository")
+		assert.Equal(t,
+			[]string{"apply", "--non-interactive", "-auto-approve"},
+			upgradeRepository.LastArguments,
+			"Should strip --reply and append --non-interactive and -auto-approve",
+		)
+		assert.Equal(t, 0, interactiveRepository.ExecuteWithAnswerCallCount, "PTY path is no longer used")
 		assert.Equal(t, 0, repository.ExecuteCallCount, "Should not use normal repository")
+	})
+
+	t.Run("should inject --non-interactive and -auto-approve when --yes is used on apply", func(t *testing.T) {
+		t.Parallel()
+		// GIVEN: A command with the new --yes flag on apply
+		installCommand := &commanddoubles.StubInstallDependencies{}
+		formatCommand := &commanddoubles.StubFormatFiles{}
+		additionalBefore := &commanddoubles.StubRunAdditionalBefore{}
+		repository := &repositorydoubles.StubShellRepositoryForRoot{}
+		upgradeRepository := &repositorydoubles.StubUpgradeShellRepository{}
+		interactiveRepository := &repositorydoubles.StubInteractiveShellRepository{}
+		cmd := commands.NewRunFromRootCommand(
+			entitybuilders.NewSettingsBuilder().BuildSettings(),
+			installCommand,
+			formatCommand,
+			additionalBefore,
+			&commanddoubles.StubParallelState{},
+			repository,
+			upgradeRepository,
+			interactiveRepository,
+		)
+
+		targetPath := "/test/path"
+		arguments := []string{"apply", "--yes"}
+		dependencies := []entities.Dependency{}
+
+		// WHEN: Executing the command
+		cmd.Execute(targetPath, arguments, dependencies)
+
+		// THEN: Routes through the upgrade repository with native flags injected
+		assert.Equal(t, 1, upgradeRepository.ExecuteCallCount, "Should use upgrade repository")
+		assert.Equal(t,
+			[]string{"apply", "--non-interactive", "-auto-approve"},
+			upgradeRepository.LastArguments,
+			"Should strip --yes and append --non-interactive and -auto-approve",
+		)
+		assert.Equal(t, 0, interactiveRepository.ExecuteWithAnswerCallCount, "PTY path is no longer used")
+	})
+
+	t.Run("should inject only --non-interactive when --no is used on apply", func(t *testing.T) {
+		t.Parallel()
+		// GIVEN: A command with the new --no flag on apply
+		installCommand := &commanddoubles.StubInstallDependencies{}
+		formatCommand := &commanddoubles.StubFormatFiles{}
+		additionalBefore := &commanddoubles.StubRunAdditionalBefore{}
+		repository := &repositorydoubles.StubShellRepositoryForRoot{}
+		upgradeRepository := &repositorydoubles.StubUpgradeShellRepository{}
+		interactiveRepository := &repositorydoubles.StubInteractiveShellRepository{}
+		cmd := commands.NewRunFromRootCommand(
+			entitybuilders.NewSettingsBuilder().BuildSettings(),
+			installCommand,
+			formatCommand,
+			additionalBefore,
+			&commanddoubles.StubParallelState{},
+			repository,
+			upgradeRepository,
+			interactiveRepository,
+		)
+
+		targetPath := "/test/path"
+		arguments := []string{"apply", "--no"}
+		dependencies := []entities.Dependency{}
+
+		// WHEN: Executing the command
+		cmd.Execute(targetPath, arguments, dependencies)
+
+		// THEN: --non-interactive is injected but not -auto-approve, so terraform's
+		// apply prompt aborts instead of proceeding, matching "no" semantics.
+		assert.Equal(t, 1, upgradeRepository.ExecuteCallCount, "Should use upgrade repository")
+		assert.Equal(t,
+			[]string{"apply", "--non-interactive"},
+			upgradeRepository.LastArguments,
+			"Should strip --no and append only --non-interactive",
+		)
+		assert.Equal(t, 0, interactiveRepository.ExecuteWithAnswerCallCount, "PTY path is no longer used")
 	})
 }
 

--- a/internal/domain/commands/run_from_root_error_builders.go
+++ b/internal/domain/commands/run_from_root_error_builders.go
@@ -109,12 +109,13 @@ func buildEchoedCommand(arguments []string, targetPath string) string {
 }
 
 // buildParallelSuggestion builds the terra-managed parallel form of the user's intent,
-// suitable as a copy-pasteable example in a validation error. --reply is appended only
-// when the command is interactive (apply/destroy), because terra rejects those without it.
+// suitable as a copy-pasteable example in a validation error. --yes is appended only
+// when the command is interactive (apply/destroy), because terra rejects those without
+// a confirmation flag.
 func buildParallelSuggestion(
 	subcommand string,
 	onlyValues, skipValues []string,
-	needsReply bool,
+	needsConfirmation bool,
 	targetPath string,
 ) string {
 	parts := []string{"terra"}
@@ -128,8 +129,8 @@ func buildParallelSuggestion(
 	if len(skipValues) > 0 {
 		parts = append(parts, "--skip="+strings.Join(skipValues, ","))
 	}
-	if needsReply {
-		parts = append(parts, "--reply")
+	if needsConfirmation {
+		parts = append(parts, "--yes")
 	}
 	if targetPath != "" {
 		parts = append(parts, targetPath)
@@ -170,11 +171,11 @@ func BuildSelectionFlagsError(arguments []string, targetPath string) string {
 	subcommand := extractSubcommand(arguments)
 	onlyValues, _ := GetOnlyValues(arguments)
 	skipValues, _ := GetSkipValues(arguments)
-	needsReply := IsInteractiveCommand(arguments)
+	needsConfirmation := IsInteractiveCommand(arguments)
 
 	echoed := buildEchoedCommand(arguments, targetPath)
 	parallelSuggestion := buildParallelSuggestion(
-		subcommand, onlyValues, skipValues, needsReply, targetPath,
+		subcommand, onlyValues, skipValues, needsConfirmation, targetPath,
 	)
 	allSuggestion := buildAllWithFilterSuggestion(subcommand, onlyValues, skipValues, targetPath)
 
@@ -205,11 +206,11 @@ func BuildParallelAllConflictError(arguments []string, targetPath string) string
 	subcommand := extractSubcommand(arguments)
 	onlyValues, _ := GetOnlyValues(arguments)
 	skipValues, _ := GetSkipValues(arguments)
-	needsReply := IsInteractiveCommand(arguments)
+	needsConfirmation := IsInteractiveCommand(arguments)
 
 	echoed := buildEchoedCommand(arguments, targetPath)
 	parallelSuggestion := buildParallelSuggestion(
-		subcommand, onlyValues, skipValues, needsReply, targetPath,
+		subcommand, onlyValues, skipValues, needsConfirmation, targetPath,
 	)
 	allSuggestion := buildAllWithFilterSuggestion(subcommand, onlyValues, skipValues, targetPath)
 

--- a/internal/domain/commands/run_from_root_error_builders_test.go
+++ b/internal/domain/commands/run_from_root_error_builders_test.go
@@ -68,20 +68,20 @@ func TestBuildSelectionFlagsError(t *testing.T) {
 		assert.Contains(t, message, "terra plan --all --filter='mod1' --filter='mod2' /infra")
 	})
 
-	t.Run("should include --reply in the --parallel suggestion for apply", func(t *testing.T) {
+	t.Run("should include --yes in the --parallel suggestion for apply", func(t *testing.T) {
 		t.Parallel()
-		// GIVEN: apply is an interactive command and terra requires --reply for it
+		// GIVEN: apply is an interactive command and terra requires a confirmation flag for it
 		arguments := []string{"apply", "--skip=mod1"}
 		targetPath := "/infra"
 
 		// WHEN: Building the error
 		message := commands.BuildSelectionFlagsError(arguments, targetPath)
 
-		// THEN: The --parallel suggestion includes --reply
-		assert.Contains(t, message, "terra apply --parallel=5 --skip=mod1 --reply /infra")
+		// THEN: The --parallel suggestion includes --yes
+		assert.Contains(t, message, "terra apply --parallel=5 --skip=mod1 --yes /infra")
 	})
 
-	t.Run("should include --reply in the --parallel suggestion for destroy", func(t *testing.T) {
+	t.Run("should include --yes in the --parallel suggestion for destroy", func(t *testing.T) {
 		t.Parallel()
 		// GIVEN: destroy is also interactive
 		arguments := []string{"destroy", "--only=mod1"}
@@ -90,11 +90,11 @@ func TestBuildSelectionFlagsError(t *testing.T) {
 		// WHEN: Building the error
 		message := commands.BuildSelectionFlagsError(arguments, targetPath)
 
-		// THEN: The --parallel suggestion includes --reply
-		assert.Contains(t, message, "terra destroy --parallel=5 --only=mod1 --reply /infra")
+		// THEN: The --parallel suggestion includes --yes
+		assert.Contains(t, message, "terra destroy --parallel=5 --only=mod1 --yes /infra")
 	})
 
-	t.Run("should NOT include --reply in the --parallel suggestion for plan", func(t *testing.T) {
+	t.Run("should NOT include --yes in the --parallel suggestion for plan", func(t *testing.T) {
 		t.Parallel()
 		// GIVEN: plan is not an interactive command
 		arguments := []string{"plan", "--skip=mod1"}
@@ -103,9 +103,9 @@ func TestBuildSelectionFlagsError(t *testing.T) {
 		// WHEN: Building the error
 		message := commands.BuildSelectionFlagsError(arguments, targetPath)
 
-		// THEN: The --parallel suggestion does NOT include --reply
+		// THEN: The --parallel suggestion does NOT include --yes
 		assert.Contains(t, message, "terra plan --parallel=5 --skip=mod1 /infra")
-		assert.NotContains(t, message, "terra plan --parallel=5 --skip=mod1 --reply")
+		assert.NotContains(t, message, "terra plan --parallel=5 --skip=mod1 --yes")
 	})
 
 	t.Run("should preserve the target path in both suggestion lines", func(t *testing.T) {

--- a/internal/domain/commands/run_from_root_validation_test.go
+++ b/internal/domain/commands/run_from_root_validation_test.go
@@ -101,7 +101,7 @@ func TestRunFromRootCommand_validateDeprecatedFlags(t *testing.T) {
 		require.NotEmpty(t, hook.Entries)
 		lastEntry := hook.LastEntry()
 		assert.Equal(t, logger.FatalLevel, lastEntry.Level)
-		assert.Contains(t, lastEntry.Message, "--auto-answer has been renamed to --reply")
+		assert.Contains(t, lastEntry.Message, "--auto-answer has been replaced by --yes")
 	})
 
 	t.Run("should fatalf when --auto-answer boolean flag is used", func(t *testing.T) {
@@ -119,7 +119,7 @@ func TestRunFromRootCommand_validateDeprecatedFlags(t *testing.T) {
 		require.NotEmpty(t, hook.Entries)
 		lastEntry := hook.LastEntry()
 		assert.Equal(t, logger.FatalLevel, lastEntry.Level)
-		assert.Contains(t, lastEntry.Message, "--auto-answer has been renamed to --reply")
+		assert.Contains(t, lastEntry.Message, "--auto-answer has been replaced by --yes")
 	})
 
 	t.Run("should fatalf when --all is used with state commands", func(t *testing.T) {
@@ -217,8 +217,8 @@ func TestRunFromRootCommand_validateFlagCombinations(t *testing.T) {
 		assert.Contains(t, lastEntry.Message, "terra plan --all /test/path")
 	})
 
-	t.Run("should fatalf when --parallel is used with apply without --reply", func(t *testing.T) {
-		// GIVEN: Arguments containing --parallel with apply but no --reply
+	t.Run("should fatalf when --parallel is used with apply without confirmation flag", func(t *testing.T) {
+		// GIVEN: Arguments containing --parallel with apply but no --yes/--no/--reply
 		hook, cleanup := setupFatalInterceptor()
 		defer cleanup()
 		cmd := newRunFromRootForValidation()
@@ -228,15 +228,15 @@ func TestRunFromRootCommand_validateFlagCombinations(t *testing.T) {
 		// WHEN: Executing the command
 		cmd.Execute("/test/path", arguments, dependencies)
 
-		// THEN: Should log a fatal error about missing --reply flag
+		// THEN: Should log a fatal error requiring a confirmation flag
 		require.NotEmpty(t, hook.Entries)
 		lastEntry := hook.LastEntry()
 		assert.Equal(t, logger.FatalLevel, lastEntry.Level)
-		assert.Contains(t, lastEntry.Message, "--reply is required when using --parallel with apply or destroy")
+		assert.Contains(t, lastEntry.Message, "--yes is required when using --parallel with apply or destroy")
 	})
 
-	t.Run("should fatalf when --parallel is used with destroy without --reply", func(t *testing.T) {
-		// GIVEN: Arguments containing --parallel with destroy but no --reply
+	t.Run("should fatalf when --parallel is used with destroy without confirmation flag", func(t *testing.T) {
+		// GIVEN: Arguments containing --parallel with destroy but no --yes/--no/--reply
 		hook, cleanup := setupFatalInterceptor()
 		defer cleanup()
 		cmd := newRunFromRootForValidation()
@@ -246,15 +246,15 @@ func TestRunFromRootCommand_validateFlagCombinations(t *testing.T) {
 		// WHEN: Executing the command
 		cmd.Execute("/test/path", arguments, dependencies)
 
-		// THEN: Should log a fatal error about missing --reply flag
+		// THEN: Should log a fatal error requiring a confirmation flag
 		require.NotEmpty(t, hook.Entries)
 		lastEntry := hook.LastEntry()
 		assert.Equal(t, logger.FatalLevel, lastEntry.Level)
-		assert.Contains(t, lastEntry.Message, "--reply is required when using --parallel with apply or destroy")
+		assert.Contains(t, lastEntry.Message, "--yes is required when using --parallel with apply or destroy")
 	})
 
-	t.Run("should warn when --reply has explicit value with --parallel", func(t *testing.T) {
-		// GIVEN: Arguments containing --parallel with --reply=y (explicit value)
+	t.Run("should not fatalf when --parallel is used with apply and --yes", func(t *testing.T) {
+		// GIVEN: Arguments containing --parallel with apply and the new --yes flag
 		hook, cleanup := setupFatalInterceptor()
 		defer cleanup()
 
@@ -272,89 +272,50 @@ func TestRunFromRootCommand_validateFlagCombinations(t *testing.T) {
 			&repositorydoubles.StubUpgradeShellRepository{},
 			&repositorydoubles.StubInteractiveShellRepository{},
 		)
-		arguments := []string{"apply", "--parallel=2", "--reply=y"}
+		arguments := []string{"apply", "--parallel=2", "--yes"}
 		dependencies := []entities.Dependency{}
 
 		// WHEN: Executing the command
 		cmd.Execute("/test/path", arguments, dependencies)
 
-		// THEN: Should log a warning about the reply value being ignored
-		var foundWarning bool
+		// THEN: Validation passes and parallel execution proceeds
 		for _, entry := range hook.Entries {
-			if entry.Level == logger.WarnLevel &&
-				assert.ObjectsAreEqual("The --reply value is ignored for terra-managed parallel execution (--parallel). It is only used with --all for terragrunt-managed parallelism, where the PTY uses the value to answer prompts. Just --reply without a value is sufficient when using --parallel.", entry.Message) {
-				foundWarning = true
-			}
-		}
-		assert.True(t, foundWarning, "Should log a warning about --reply value being ignored")
-		assert.True(t, parallelState.ExecuteCalled, "Should still proceed to parallel execution")
-	})
-
-	t.Run("should not warn when --reply has no value with --parallel", func(t *testing.T) {
-		// GIVEN: Arguments containing --parallel with --reply (boolean form, no value)
-		hook, cleanup := setupFatalInterceptor()
-		defer cleanup()
-
-		parallelState := &commanddoubles.StubParallelState{}
-		cmd := commands.NewRunFromRootCommand(
-			entitybuilders.NewSettingsBuilder().
-				WithTerraModuleCacheDir("/tmp/terra-test-modules").
-				WithTerraProviderCacheDir("/tmp/terra-test-providers").
-				BuildSettings(),
-			&commanddoubles.StubInstallDependencies{},
-			&commanddoubles.StubFormatFiles{},
-			&commanddoubles.StubRunAdditionalBefore{},
-			parallelState,
-			&repositorydoubles.StubShellRepositoryForRoot{},
-			&repositorydoubles.StubUpgradeShellRepository{},
-			&repositorydoubles.StubInteractiveShellRepository{},
-		)
-		arguments := []string{"apply", "--parallel=2", "--reply"}
-		dependencies := []entities.Dependency{}
-
-		// WHEN: Executing the command
-		cmd.Execute("/test/path", arguments, dependencies)
-
-		// THEN: Should not log any warning about reply value
-		for _, entry := range hook.Entries {
-			if entry.Level == logger.WarnLevel {
-				assert.NotContains(t, entry.Message, "--reply value is ignored",
-					"Should not warn when --reply has no explicit value")
-			}
+			assert.NotEqual(t, logger.FatalLevel, entry.Level,
+				"Should not produce a fatal log entry for --parallel apply with --yes")
 		}
 		assert.True(t, parallelState.ExecuteCalled, "Should proceed to parallel execution")
 	})
 
-	t.Run("should fatalf when --all is used with --reply without explicit value", func(t *testing.T) {
-		// GIVEN: Arguments containing --all with --reply (boolean form, no explicit value)
+	t.Run("should warn when --reply is used with any command", func(t *testing.T) {
+		// GIVEN: Arguments containing the deprecated --reply flag
 		hook, cleanup := setupFatalInterceptor()
 		defer cleanup()
 		cmd := newRunFromRootForValidation()
-		arguments := []string{"apply", "--all", "--reply"}
+		arguments := []string{"plan", "--reply=y"}
 		dependencies := []entities.Dependency{}
 
 		// WHEN: Executing the command
 		cmd.Execute("/test/path", arguments, dependencies)
 
-		// THEN: Should log a fatal error requiring an explicit value
-		// (execution continues after intercepted Fatalf, so search all entries)
-		var foundFatal bool
+		// THEN: Emits a migration warning pointing at --yes
+		var foundWarning bool
 		for _, entry := range hook.Entries {
-			if entry.Level == logger.FatalLevel {
-				assert.Contains(t, entry.Message, "--reply requires an explicit value when used with --all")
-				foundFatal = true
-				break
+			if entry.Level == logger.WarnLevel &&
+				strings.Contains(entry.Message, "--reply/-r is deprecated") &&
+				strings.Contains(entry.Message, "Use --yes") {
+				foundWarning = true
 			}
 		}
-		assert.True(t, foundFatal, "Should have logged a fatal error about --reply requiring an explicit value")
+		assert.True(t, foundWarning, "Should log a deprecation warning for --reply")
 	})
 
 	t.Run("should not fatalf when --all is used with --reply=y", func(t *testing.T) {
-		// GIVEN: Arguments containing --all with --reply=y (explicit value)
+		// GIVEN: Arguments containing --all with --reply=y (valid under the new
+		// flag-injection path; the old PTY-era "requires explicit value" rule is gone).
 		hook, cleanup := setupFatalInterceptor()
 		defer cleanup()
 
-		interactiveRepository := &repositorydoubles.StubInteractiveShellRepository{}
+		upgradeRepository := &repositorydoubles.StubUpgradeShellRepository{}
 		cmd := commands.NewRunFromRootCommand(
 			entitybuilders.NewSettingsBuilder().
 				WithTerraModuleCacheDir("/tmp/terra-test-modules").
@@ -365,8 +326,8 @@ func TestRunFromRootCommand_validateFlagCombinations(t *testing.T) {
 			&commanddoubles.StubRunAdditionalBefore{},
 			&commanddoubles.StubParallelState{},
 			&repositorydoubles.StubShellRepositoryForRoot{},
-			&repositorydoubles.StubUpgradeShellRepository{},
-			interactiveRepository,
+			upgradeRepository,
+			&repositorydoubles.StubInteractiveShellRepository{},
 		)
 		arguments := []string{"apply", "--all", "--reply=y"}
 		dependencies := []entities.Dependency{}
@@ -374,7 +335,7 @@ func TestRunFromRootCommand_validateFlagCombinations(t *testing.T) {
 		// WHEN: Executing the command
 		cmd.Execute("/test/path", arguments, dependencies)
 
-		// THEN: Should not log any fatal error (--all with explicit --reply=y is valid)
+		// THEN: Should not log any fatal error
 		for _, entry := range hook.Entries {
 			assert.NotEqual(t, logger.FatalLevel, entry.Level,
 				"Should not produce a fatal log entry for --all with --reply=y")
@@ -426,7 +387,7 @@ func TestRunFromRootCommand_validateSelectionFlags(t *testing.T) {
 		assert.Contains(t, lastEntry.Message, "terra plan --all --filter='!mod1' /test/path")
 	})
 
-	t.Run("should include --reply in the --parallel suggestion for apply", func(t *testing.T) {
+	t.Run("should include --yes in the --parallel suggestion for apply", func(t *testing.T) {
 		// GIVEN: apply with --skip but without --parallel (and without --all)
 		hook, cleanup := setupFatalInterceptor()
 		defer cleanup()
@@ -437,7 +398,7 @@ func TestRunFromRootCommand_validateSelectionFlags(t *testing.T) {
 		// WHEN: Executing the command
 		cmd.Execute("/test/path", arguments, dependencies)
 
-		// THEN: The suggestion for the --parallel path includes --reply because
+		// THEN: The suggestion for the --parallel path includes --yes because
 		// apply is interactive and terra rejects --parallel apply without it
 		require.NotEmpty(t, hook.Entries)
 		lastEntry := hook.LastEntry()
@@ -445,7 +406,7 @@ func TestRunFromRootCommand_validateSelectionFlags(t *testing.T) {
 		assert.Contains(
 			t,
 			lastEntry.Message,
-			"terra apply --parallel=5 --skip=mod1 --reply /test/path",
+			"terra apply --parallel=5 --skip=mod1 --yes /test/path",
 		)
 	})
 }
@@ -816,14 +777,13 @@ func TestRunFromRootCommand_Execute_terragruntFails(t *testing.T) {
 		assert.Contains(t, lastEntry.Message, "Terragrunt command failed")
 	})
 
-	t.Run("should fatalf when interactive repository returns error", func(t *testing.T) {
-		// GIVEN: An interactive repository that returns an error
+	t.Run("should fatalf when upgrade repository returns error with --yes", func(t *testing.T) {
+		// GIVEN: An upgrade repository that returns an error while --yes is set
 		hook, cleanup := setupFatalInterceptor()
 		defer cleanup()
 
-		interactiveRepository := &repositorydoubles.StubInteractiveShellRepository{
-			ShouldReturnError: true,
-			ExecuteError:      assert.AnError,
+		upgradeRepository := &repositorydoubles.StubUpgradeShellRepository{
+			ErrorToReturn: assert.AnError,
 		}
 		cmd := commands.NewRunFromRootCommand(
 			entitybuilders.NewSettingsBuilder().
@@ -835,10 +795,10 @@ func TestRunFromRootCommand_Execute_terragruntFails(t *testing.T) {
 			&commanddoubles.StubRunAdditionalBefore{},
 			&commanddoubles.StubParallelState{},
 			&repositorydoubles.StubShellRepositoryForRoot{},
-			&repositorydoubles.StubUpgradeShellRepository{},
-			interactiveRepository,
+			upgradeRepository,
+			&repositorydoubles.StubInteractiveShellRepository{},
 		)
-		arguments := []string{"--reply=y", "plan"}
+		arguments := []string{"--yes", "apply"}
 		dependencies := []entities.Dependency{}
 
 		// WHEN: Executing the command

--- a/internal/domain/commands/run_from_root_validation_test.go
+++ b/internal/domain/commands/run_from_root_validation_test.go
@@ -232,7 +232,7 @@ func TestRunFromRootCommand_validateFlagCombinations(t *testing.T) {
 		require.NotEmpty(t, hook.Entries)
 		lastEntry := hook.LastEntry()
 		assert.Equal(t, logger.FatalLevel, lastEntry.Level)
-		assert.Contains(t, lastEntry.Message, "--yes is required when using --parallel with apply or destroy")
+		assert.Contains(t, lastEntry.Message, "a confirmation flag is required when using --parallel with apply or destroy")
 	})
 
 	t.Run("should fatalf when --parallel is used with destroy without confirmation flag", func(t *testing.T) {
@@ -250,7 +250,7 @@ func TestRunFromRootCommand_validateFlagCombinations(t *testing.T) {
 		require.NotEmpty(t, hook.Entries)
 		lastEntry := hook.LastEntry()
 		assert.Equal(t, logger.FatalLevel, lastEntry.Level)
-		assert.Contains(t, lastEntry.Message, "--yes is required when using --parallel with apply or destroy")
+		assert.Contains(t, lastEntry.Message, "a confirmation flag is required when using --parallel with apply or destroy")
 	})
 
 	t.Run("should not fatalf when --parallel is used with apply and --yes", func(t *testing.T) {

--- a/internal/domain/commands/state_utils.go
+++ b/internal/domain/commands/state_utils.go
@@ -395,17 +395,32 @@ func HasConfirmationFlag(arguments []string) bool {
 }
 
 // RemoveConfirmationFlags removes every terra-level confirmation flag from arguments
-// (--yes/-y, --no/-n, and all forms of the deprecated --reply/-r).
+// (--yes/-y, --no/-n, and all forms of the deprecated --reply/-r, including the
+// space-separated form --reply y / -r y where the value is a separate argument).
+//
+// The space-form heuristic only consumes the next argument when it is a recognised
+// reply value (y/yes/n/no/true/false/0/1). This avoids swallowing the subcommand
+// in inputs like "--reply plan" (bare --reply followed by the Terragrunt command).
 func RemoveConfirmationFlags(arguments []string) []string {
 	filtered := make([]string, 0, len(arguments))
-	for _, arg := range arguments {
+	skipNext := false
+	for index, arg := range arguments {
+		if skipNext {
+			skipNext = false
+			continue
+		}
 		if arg == YesFlag || arg == YesShortFlag ||
 			arg == NoFlag || arg == NoShortFlag {
 			continue
 		}
-		if arg == ReplyFlag || arg == ReplyShortFlag ||
-			strings.HasPrefix(arg, ReplyFlag+"=") ||
+		if strings.HasPrefix(arg, ReplyFlag+"=") ||
 			strings.HasPrefix(arg, ReplyShortFlag+"=") {
+			continue
+		}
+		if arg == ReplyFlag || arg == ReplyShortFlag {
+			if index+1 < len(arguments) && isRecognisedReplyValue(arguments[index+1]) {
+				skipNext = true
+			}
 			continue
 		}
 		filtered = append(filtered, arg)
@@ -413,12 +428,25 @@ func RemoveConfirmationFlags(arguments []string) []string {
 	return filtered
 }
 
+// isRecognisedReplyValue returns true when the token is one of the literal reply
+// values that could follow --reply / -r in the space-separated form. Anything
+// else (subcommands, paths, targets) is not a reply value and must not be consumed.
+func isRecognisedReplyValue(token string) bool {
+	switch strings.ToLower(token) {
+	case "y", "yes", "true", "1", "n", "no", "false", "0":
+		return true
+	default:
+		return false
+	}
+}
+
 // ResolveConfirmation returns which terra-level confirmation intent is present
 // as a pair of booleans (isYes, isNo). Legacy --reply/-r forms are mapped:
-// --reply=y maps to yes, --reply=n maps to no, and bare --reply (or -r) defaults
-// to yes. The bare default matches the old --parallel path, which injected
-// --non-interactive -auto-approve for bare --reply; the PTY path's "answer n"
-// default was an accidental side effect that often blocked CI pipelines.
+// --reply=y and --reply y map to yes, --reply=n and --reply n map to no, and
+// bare --reply (or -r) with no following value defaults to yes. The bare default
+// matches the old --parallel path, which injected --non-interactive -auto-approve
+// for bare --reply; the PTY path's "answer n" default was an accidental side
+// effect that often blocked CI pipelines.
 func ResolveConfirmation(arguments []string) (bool, bool) {
 	if HasYesFlag(arguments) {
 		return true, false
@@ -431,15 +459,24 @@ func ResolveConfirmation(arguments []string) (bool, bool) {
 		return false, false
 	}
 
-	for _, arg := range arguments {
+	for index, arg := range arguments {
 		if after, ok := strings.CutPrefix(arg, ReplyFlag+"="); ok {
 			return mapReplyValueToConfirmation(after)
 		}
 		if after, ok := strings.CutPrefix(arg, ReplyShortFlag+"="); ok {
 			return mapReplyValueToConfirmation(after)
 		}
+		if arg == ReplyFlag || arg == ReplyShortFlag {
+			// Space-separated form: --reply y / -r n. Only consume the next
+			// argument as the value when it is a recognised reply value, so
+			// we don't misinterpret "--reply plan" (bare --reply + subcommand).
+			if index+1 < len(arguments) && isRecognisedReplyValue(arguments[index+1]) {
+				return mapReplyValueToConfirmation(arguments[index+1])
+			}
+			// Bare --reply / -r with no following value: default to yes.
+			return true, false
+		}
 	}
-	// Bare --reply or -r with no value: default to yes.
 	return true, false
 }
 

--- a/internal/domain/commands/state_utils.go
+++ b/internal/domain/commands/state_utils.go
@@ -17,6 +17,15 @@ const (
 	// SkipFlagPrefix represents the prefix for the --skip flag (exclude specific modules).
 	SkipFlagPrefix = "--skip="
 
+	// YesFlag represents the --yes flag (auto-approve, non-interactive).
+	YesFlag = "--yes"
+	// YesShortFlag represents the -y short flag for --yes.
+	YesShortFlag = "-y"
+	// NoFlag represents the --no flag (non-interactive, abort on confirm prompts).
+	NoFlag = "--no"
+	// NoShortFlag represents the -n short flag for --no.
+	NoShortFlag = "-n"
+
 	// DeprecatedNoParallelBypassFlag is the removed --no-parallel-bypass flag.
 	DeprecatedNoParallelBypassFlag = "--no-parallel-bypass"
 	// DeprecatedIncludeFlagPrefix is the renamed --include flag (now --only).
@@ -357,4 +366,115 @@ func RemoveReplyFlag(arguments []string) []string {
 		}
 	}
 	return filtered
+}
+
+// HasYesFlag checks if --yes or -y is present in arguments.
+func HasYesFlag(arguments []string) bool {
+	for _, arg := range arguments {
+		if arg == YesFlag || arg == YesShortFlag {
+			return true
+		}
+	}
+	return false
+}
+
+// HasNoFlag checks if --no or -n is present in arguments.
+func HasNoFlag(arguments []string) bool {
+	for _, arg := range arguments {
+		if arg == NoFlag || arg == NoShortFlag {
+			return true
+		}
+	}
+	return false
+}
+
+// HasConfirmationFlag returns true when any terra-level confirmation flag is present:
+// --yes/-y, --no/-n, or the deprecated --reply/-r forms.
+func HasConfirmationFlag(arguments []string) bool {
+	return HasYesFlag(arguments) || HasNoFlag(arguments) || HasReplyFlag(arguments)
+}
+
+// RemoveConfirmationFlags removes every terra-level confirmation flag from arguments
+// (--yes/-y, --no/-n, and all forms of the deprecated --reply/-r).
+func RemoveConfirmationFlags(arguments []string) []string {
+	filtered := make([]string, 0, len(arguments))
+	for _, arg := range arguments {
+		if arg == YesFlag || arg == YesShortFlag ||
+			arg == NoFlag || arg == NoShortFlag {
+			continue
+		}
+		if arg == ReplyFlag || arg == ReplyShortFlag ||
+			strings.HasPrefix(arg, ReplyFlag+"=") ||
+			strings.HasPrefix(arg, ReplyShortFlag+"=") {
+			continue
+		}
+		filtered = append(filtered, arg)
+	}
+	return filtered
+}
+
+// ResolveConfirmation returns which terra-level confirmation intent is present
+// as a pair of booleans (isYes, isNo). Legacy --reply/-r forms are mapped:
+// --reply=y maps to yes, --reply=n maps to no, and bare --reply (or -r) defaults
+// to yes. The bare default matches the old --parallel path, which injected
+// --non-interactive -auto-approve for bare --reply; the PTY path's "answer n"
+// default was an accidental side effect that often blocked CI pipelines.
+func ResolveConfirmation(arguments []string) (bool, bool) {
+	if HasYesFlag(arguments) {
+		return true, false
+	}
+	if HasNoFlag(arguments) {
+		return false, true
+	}
+
+	if !HasReplyFlag(arguments) {
+		return false, false
+	}
+
+	for _, arg := range arguments {
+		if after, ok := strings.CutPrefix(arg, ReplyFlag+"="); ok {
+			return mapReplyValueToConfirmation(after)
+		}
+		if after, ok := strings.CutPrefix(arg, ReplyShortFlag+"="); ok {
+			return mapReplyValueToConfirmation(after)
+		}
+	}
+	// Bare --reply or -r with no value: default to yes.
+	return true, false
+}
+
+// mapReplyValueToConfirmation translates a legacy --reply=<value> suffix into
+// the equivalent (isYes, isNo) intent. Anything that looks like a negative
+// answer maps to no; everything else (including unknown values) maps to yes.
+func mapReplyValueToConfirmation(value string) (bool, bool) {
+	switch strings.ToLower(value) {
+	case "n", "no", "false", "0":
+		return false, true
+	default:
+		return true, false
+	}
+}
+
+// BuildConfirmationInjection returns the native Terraform/Terragrunt flags that
+// should be appended to the forwarded argument list based on the presence of
+// --yes/--no (or the deprecated --reply forms).
+//
+//   - --yes injects --non-interactive (so Terragrunt assumes "yes" for its own
+//     prompts) and, for apply/destroy, -auto-approve (so Terraform skips its own
+//     confirmation, which --non-interactive alone does not suppress).
+//   - --no injects only --non-interactive. Without -auto-approve, Terraform's
+//     apply/destroy prompt aborts instead of proceeding, which matches "no".
+//
+// Returns nil when no confirmation flag is present.
+func BuildConfirmationInjection(arguments []string) []string {
+	yes, no := ResolveConfirmation(arguments)
+	if !yes && !no {
+		return nil
+	}
+
+	injected := []string{"--non-interactive"}
+	if yes && IsInteractiveCommand(arguments) {
+		injected = append(injected, "-auto-approve")
+	}
+	return injected
 }

--- a/internal/domain/commands/state_utils_test.go
+++ b/internal/domain/commands/state_utils_test.go
@@ -597,6 +597,26 @@ func TestRemoveConfirmationFlags(t *testing.T) {
 			[]string{"apply"},
 		},
 		{
+			"should strip space-separated --reply y",
+			[]string{"apply", "--reply", "y"},
+			[]string{"apply"},
+		},
+		{
+			"should strip space-separated -r n and keep trailing target path",
+			[]string{"apply", "-r", "n", "/path/to/module"},
+			[]string{"apply", "/path/to/module"},
+		},
+		{
+			"should keep a following flag when --reply has no value",
+			[]string{"apply", "--reply", "--parallel=4"},
+			[]string{"apply", "--parallel=4"},
+		},
+		{
+			"should not consume the subcommand after bare --reply",
+			[]string{"--reply", "plan", "--detailed-exitcode"},
+			[]string{"plan", "--detailed-exitcode"},
+		},
+		{
 			"should leave arguments unchanged when no confirmation flag present",
 			[]string{"apply", "-target=mod"},
 			[]string{"apply", "-target=mod"},
@@ -627,6 +647,9 @@ func TestResolveConfirmation(t *testing.T) {
 		{"should map bare --reply to yes (default)", []string{"apply", "--reply"}, true, false},
 		{"should map bare -r to yes (default)", []string{"apply", "-r"}, true, false},
 		{"should map --reply=no to no", []string{"apply", "--reply=no"}, false, true},
+		{"should map space-separated --reply y to yes", []string{"apply", "--reply", "y"}, true, false},
+		{"should map space-separated -r n to no", []string{"apply", "-r", "n"}, false, true},
+		{"should map bare --reply followed by another flag to yes", []string{"apply", "--reply", "--parallel=4"}, true, false},
 		{"should return false,false when no confirmation flag", []string{"apply"}, false, false},
 	}
 

--- a/internal/domain/commands/state_utils_test.go
+++ b/internal/domain/commands/state_utils_test.go
@@ -494,3 +494,201 @@ func TestGetReplyValue(t *testing.T) {
 		})
 	}
 }
+
+func TestHasYesFlag(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		arguments []string
+		expected  bool
+	}{
+		{"should return true when --yes present", []string{"apply", "--yes"}, true},
+		{"should return true when -y present", []string{"apply", "-y"}, true},
+		{"should return false when only --no present", []string{"apply", "--no"}, false},
+		{"should return false when absent", []string{"apply"}, false},
+		{"should return false when empty arguments", []string{}, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tt.expected, commands.HasYesFlag(tt.arguments))
+		})
+	}
+}
+
+func TestHasNoFlag(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		arguments []string
+		expected  bool
+	}{
+		{"should return true when --no present", []string{"apply", "--no"}, true},
+		{"should return true when -n present", []string{"apply", "-n"}, true},
+		{"should return false when only --yes present", []string{"apply", "--yes"}, false},
+		{"should return false when absent", []string{"apply"}, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tt.expected, commands.HasNoFlag(tt.arguments))
+		})
+	}
+}
+
+func TestHasConfirmationFlag(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		arguments []string
+		expected  bool
+	}{
+		{"should return true when --yes present", []string{"apply", "--yes"}, true},
+		{"should return true when --no present", []string{"apply", "--no"}, true},
+		{"should return true when deprecated --reply present", []string{"apply", "--reply"}, true},
+		{"should return true when deprecated --reply=y present", []string{"apply", "--reply=y"}, true},
+		{"should return false when absent", []string{"apply"}, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tt.expected, commands.HasConfirmationFlag(tt.arguments))
+		})
+	}
+}
+
+func TestRemoveConfirmationFlags(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		arguments []string
+		expected  []string
+	}{
+		{
+			"should strip --yes",
+			[]string{"apply", "--yes", "-target=mod"},
+			[]string{"apply", "-target=mod"},
+		},
+		{
+			"should strip -y",
+			[]string{"apply", "-y"},
+			[]string{"apply"},
+		},
+		{
+			"should strip --no",
+			[]string{"apply", "--no"},
+			[]string{"apply"},
+		},
+		{
+			"should strip -n",
+			[]string{"apply", "-n"},
+			[]string{"apply"},
+		},
+		{
+			"should strip deprecated --reply and its value forms",
+			[]string{"apply", "--reply", "-r", "--reply=y", "-r=n"},
+			[]string{"apply"},
+		},
+		{
+			"should leave arguments unchanged when no confirmation flag present",
+			[]string{"apply", "-target=mod"},
+			[]string{"apply", "-target=mod"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tt.expected, commands.RemoveConfirmationFlags(tt.arguments))
+		})
+	}
+}
+
+func TestResolveConfirmation(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		arguments  []string
+		expectYes  bool
+		expectNo   bool
+	}{
+		{"should resolve --yes to yes", []string{"apply", "--yes"}, true, false},
+		{"should resolve --no to no", []string{"apply", "--no"}, false, true},
+		{"should map --reply=y to yes", []string{"apply", "--reply=y"}, true, false},
+		{"should map --reply=n to no", []string{"apply", "--reply=n"}, false, true},
+		{"should map bare --reply to yes (default)", []string{"apply", "--reply"}, true, false},
+		{"should map bare -r to yes (default)", []string{"apply", "-r"}, true, false},
+		{"should map --reply=no to no", []string{"apply", "--reply=no"}, false, true},
+		{"should return false,false when no confirmation flag", []string{"apply"}, false, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			yes, no := commands.ResolveConfirmation(tt.arguments)
+			assert.Equal(t, tt.expectYes, yes, "yes")
+			assert.Equal(t, tt.expectNo, no, "no")
+		})
+	}
+}
+
+func TestBuildConfirmationInjection(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		arguments []string
+		expected  []string
+	}{
+		{
+			"should inject --non-interactive and -auto-approve for --yes on apply",
+			[]string{"apply", "--yes"},
+			[]string{"--non-interactive", "-auto-approve"},
+		},
+		{
+			"should inject --non-interactive and -auto-approve for --yes on destroy",
+			[]string{"destroy", "--yes"},
+			[]string{"--non-interactive", "-auto-approve"},
+		},
+		{
+			"should inject only --non-interactive for --yes on plan",
+			[]string{"plan", "--yes"},
+			[]string{"--non-interactive"},
+		},
+		{
+			"should inject only --non-interactive for --no on apply",
+			[]string{"apply", "--no"},
+			[]string{"--non-interactive"},
+		},
+		{
+			"should inject --non-interactive and -auto-approve for --reply=y on apply",
+			[]string{"apply", "--reply=y"},
+			[]string{"--non-interactive", "-auto-approve"},
+		},
+		{
+			"should inject only --non-interactive for --reply=n on apply",
+			[]string{"apply", "--reply=n"},
+			[]string{"--non-interactive"},
+		},
+		{
+			"should return nil when no confirmation flag is present",
+			[]string{"apply"},
+			nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tt.expected, commands.BuildConfirmationInjection(tt.arguments))
+		})
+	}
+}


### PR DESCRIPTION
## Summary

- Adds `--yes` / `-y` and `--no` / `-n` confirmation flags that translate into native Terraform / Terragrunt flags. `--yes` injects `--non-interactive` + `-auto-approve` (for `apply` / `destroy`); `--no` injects only `--non-interactive`, so Terraform's apply prompt aborts instead of proceeding.
- Deprecates `--reply` / `-r`. Legacy forms keep working: `--reply=y` and bare `--reply` map to `--yes`; `--reply=n` maps to `--no`. A one-time migration warning is logged.
- Fixes `terra apply --reply=y` hanging forever on Terraform's `Do you want to perform these actions? Enter a value:` prompt. The previous PTY auto-responder only matched `[y/n]` and "external dependency" prompts, so Terraform's apply confirmation (which requires the literal word `yes`) was never answered. The new flag-injection path invokes `-auto-approve` natively and works reliably.

## Why

Industry convention (`apt`, `npm`, `yarn`, `pnpm`, `az`, `dnf`) is `-y` / `--yes` for "answer yes to all prompts". `--reply` was terra-specific, and its PTY-based implementation was fragile — it silently failed on the single most common use case (`terra apply` without auto-approve). Terragrunt's own `--non-interactive` flag and Terraform's `-auto-approve` solve the problem at the protocol level; this PR just translates terra-level flags into those native flags.

No upstream collisions: neither Terraform nor Terragrunt uses `-y`, `--yes`, `-n`, or bare `--no`.

## Test plan

- [x] `make lint` is clean
- [x] `make test` (unit + integration) passes
- [x] `make build` produces a working binary
- [ ] Smoke test: `terra apply --yes <module>` does not prompt (reviewer to verify against a real stack)
- [ ] Smoke test: `terra apply --reply=y <module>` emits a deprecation warning and still skips the prompt
- [ ] Smoke test: `terra apply --parallel=4 --yes <root>` runs workers without prompting

🤖 Generated with [Claude Code](https://claude.com/claude-code)