### PR TITLE
feat(install): made the download timeout configurable via env var

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@ Exceptions are acceptable depending on the circumstances (critical bug fixes tha
 
 ## [Unreleased]
 
+### Added
+
+- added `TERRA_DOWNLOAD_TIMEOUT` environment variable to override the per-download deadline `terra install` applies to the Terraform / Terragrunt fetch (default `10m`). Accepts any `time.ParseDuration` value (`30m`, `1h`, `20m30s`); malformed values fall back to the default and log a warning. Resolves the silent `failed to write downloaded content to file: context deadline exceeded` failure on slow transports -- corporate proxies, low-bandwidth links, and especially QEMU-emulated multi-arch container builds where syscall overhead pushes the Terragrunt body read past the previously hardcoded 10-minute ceiling.
+
 ## [1.15.4] - 2026-05-01
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@ Exceptions are acceptable depending on the circumstances (critical bug fixes tha
 
 ### Added
 
-- added `TERRA_DOWNLOAD_TIMEOUT` environment variable to override the per-download deadline `terra install` applies to the Terraform / Terragrunt fetch (default `10m`). Accepts any `time.ParseDuration` value (`30m`, `1h`, `20m30s`); malformed values fall back to the default and log a warning. Resolves the silent `failed to write downloaded content to file: context deadline exceeded` failure on slow transports -- corporate proxies, low-bandwidth links, and especially QEMU-emulated multi-arch container builds where syscall overhead pushes the Terragrunt body read past the previously hardcoded 10-minute ceiling.
+- added `TERRA_DOWNLOAD_TIMEOUT` environment variable to override the per-download deadline `terra install` applies to the Terraform / Terragrunt fetch (default `10m`). Accepts any `time.ParseDuration` value (`30m`, `1h`, `20m30s`); malformed or non-positive values fall back to the default and log a warning. Resolves the silent `failed to write downloaded content to file: context deadline exceeded` failure on slow transports -- corporate proxies, low-bandwidth links, and especially QEMU-emulated multi-arch container builds where syscall overhead pushes the Terragrunt body read past the previously hardcoded 10-minute ceiling.
 
 ## [1.15.4] - 2026-05-01
 

--- a/README.md
+++ b/README.md
@@ -287,13 +287,13 @@ TF_VAR_region=us-west-2
 # Optional: Disable automatic workspace selection from TERRA_WORKSPACE
 # TERRA_NO_WORKSPACE=true
 
-# Optional: Override the per-download deadline applied by `terra
-# install` to the Terraform / Terragrunt fetch (default 10 minutes).
+# Optional: Override the per-download deadline that `terra install`
+# applies to the Terraform / Terragrunt fetch (default 10 minutes).
 # Useful when slower transports (corporate proxies, low-bandwidth
 # links, QEMU-emulated multi-arch container builds) push the
 # Terragrunt download past the default. Accepts any value parseable
-# by `time.ParseDuration` -- e.g. `30m`, `1h`, `20m30s`. A malformed
-# value falls back to the default and logs a warning.
+# by `time.ParseDuration` -- e.g. `30m`, `1h`, `20m30s`. Malformed
+# or non-positive values fall back to the default and log a warning.
 # TERRA_DOWNLOAD_TIMEOUT=30m
 ```
 

--- a/README.md
+++ b/README.md
@@ -286,6 +286,15 @@ TF_VAR_region=us-west-2
 
 # Optional: Disable automatic workspace selection from TERRA_WORKSPACE
 # TERRA_NO_WORKSPACE=true
+
+# Optional: Override the per-download deadline applied by `terra
+# install` to the Terraform / Terragrunt fetch (default 10 minutes).
+# Useful when slower transports (corporate proxies, low-bandwidth
+# links, QEMU-emulated multi-arch container builds) push the
+# Terragrunt download past the default. Accepts any value parseable
+# by `time.ParseDuration` -- e.g. `30m`, `1h`, `20m30s`. A malformed
+# value falls back to the default and logs a warning.
+# TERRA_DOWNLOAD_TIMEOUT=30m
 ```
 
 **Note**: If `TERRA_CLOUD` is specified, it must be set to either "aws" or "azure". This enables cloud-specific features like role switching for AWS or subscription switching for Azure.

--- a/internal/domain/entities/os.go
+++ b/internal/domain/entities/os.go
@@ -7,10 +7,23 @@ import (
 	"net/http"
 	"os"
 	"time"
+
+	logger "github.com/sirupsen/logrus"
 )
 
 const (
-	downloadTimeout = 10 * time.Minute
+	// defaultDownloadTimeout caps a single download HTTP request +
+	// body read for `terra install`. Configurable via the
+	// `TERRA_DOWNLOAD_TIMEOUT` environment variable when slower
+	// transports (corporate proxies, QEMU-emulated multi-arch
+	// container builds, low-bandwidth links) need a longer ceiling.
+	// Accepts any `time.ParseDuration` value, e.g. `30m`, `1h`,
+	// `20m30s`.
+	defaultDownloadTimeout = 10 * time.Minute
+
+	// downloadTimeoutEnvVar is the environment-variable name that
+	// overrides `defaultDownloadTimeout`.
+	downloadTimeoutEnvVar = "TERRA_DOWNLOAD_TIMEOUT"
 )
 
 type OS interface {
@@ -23,10 +36,35 @@ type OS interface {
 	GetInstallationPath() string
 }
 
+// resolveDownloadTimeout returns the user-configured download
+// timeout from `TERRA_DOWNLOAD_TIMEOUT`, falling back to
+// `defaultDownloadTimeout` when the env var is unset, empty, or
+// fails to parse. A parse failure logs a warning and uses the
+// default so a malformed override never silently breaks installs.
+func resolveDownloadTimeout() time.Duration {
+	raw := os.Getenv(downloadTimeoutEnvVar)
+	if raw == "" {
+		return defaultDownloadTimeout
+	}
+
+	parsed, err := time.ParseDuration(raw)
+	if err != nil {
+		logger.Warnf(
+			"invalid %s=%q (%s); falling back to default %s",
+			downloadTimeoutEnvVar, raw, err, defaultDownloadTimeout,
+		)
+		return defaultDownloadTimeout
+	}
+
+	return parsed
+}
+
 // downloadFile provides a common implementation for downloading files via HTTP.
 func downloadFile(url, tempFilePath string) error {
-	// Create context with timeout for the download
-	ctx, cancel := context.WithTimeout(context.Background(), downloadTimeout)
+	// Create context with timeout for the download. Resolved at
+	// call time (not init) so tests / operators can override
+	// `TERRA_DOWNLOAD_TIMEOUT` without a process restart.
+	ctx, cancel := context.WithTimeout(context.Background(), resolveDownloadTimeout())
 	defer cancel()
 
 	// Create HTTP request with context

--- a/internal/domain/entities/os.go
+++ b/internal/domain/entities/os.go
@@ -38,9 +38,12 @@ type OS interface {
 
 // resolveDownloadTimeout returns the user-configured download
 // timeout from `TERRA_DOWNLOAD_TIMEOUT`, falling back to
-// `defaultDownloadTimeout` when the env var is unset, empty, or
-// fails to parse. A parse failure logs a warning and uses the
-// default so a malformed override never silently breaks installs.
+// `defaultDownloadTimeout` when the env var is unset, empty, fails
+// to parse, or resolves to a non-positive duration. A parse failure
+// or non-positive value logs a warning and uses the default so a
+// malformed override never silently breaks installs (a non-positive
+// `context.WithTimeout` deadline expires immediately, which would
+// abort every download before the first byte is read).
 func resolveDownloadTimeout() time.Duration {
 	raw := os.Getenv(downloadTimeoutEnvVar)
 	if raw == "" {
@@ -52,6 +55,14 @@ func resolveDownloadTimeout() time.Duration {
 		logger.Warnf(
 			"invalid %s=%q (%s); falling back to default %s",
 			downloadTimeoutEnvVar, raw, err, defaultDownloadTimeout,
+		)
+		return defaultDownloadTimeout
+	}
+
+	if parsed <= 0 {
+		logger.Warnf(
+			"non-positive %s=%q; falling back to default %s",
+			downloadTimeoutEnvVar, raw, defaultDownloadTimeout,
 		)
 		return defaultDownloadTimeout
 	}

--- a/internal/domain/entities/os_download_test.go
+++ b/internal/domain/entities/os_download_test.go
@@ -8,11 +8,14 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/rios0rios0/terra/internal/domain/entities"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+const downloadTimeoutEnvVar = "TERRA_DOWNLOAD_TIMEOUT"
 
 func TestOSUnix_Download(t *testing.T) {
 	t.Parallel()
@@ -73,5 +76,68 @@ func TestOSUnix_Download(t *testing.T) {
 
 		// then
 		assert.Error(t, err)
+	})
+
+}
+
+// `TestOSUnix_DownloadTimeout` sets `TERRA_DOWNLOAD_TIMEOUT` via
+// `t.Setenv`, which requires the test (and its parent) to be
+// non-parallel. Kept in a separate top-level function instead of as
+// subtests of `TestOSUnix_Download` (which calls `t.Parallel()`)
+// because Go rejects `Setenv` inside any test marked Parallel.
+func TestOSUnix_DownloadTimeout(t *testing.T) {
+	t.Run("should honor TERRA_DOWNLOAD_TIMEOUT when the response is slow", func(t *testing.T) {
+		// given
+		// Server sleeps longer than the configured override, so a
+		// correctly applied deadline will abort the body read with
+		// `context deadline exceeded` before the server replies.
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			time.Sleep(500 * time.Millisecond)
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte("would-be-content"))
+		}))
+		defer server.Close()
+
+		t.Setenv(downloadTimeoutEnvVar, "100ms")
+
+		tempDir := t.TempDir()
+		destPath := filepath.Join(tempDir, "downloaded_file")
+		osImpl := &entities.OSUnix{}
+
+		// when
+		err := osImpl.Download(server.URL, destPath)
+
+		// then
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "deadline exceeded")
+	})
+
+	t.Run("should fall back to default when TERRA_DOWNLOAD_TIMEOUT is malformed", func(t *testing.T) {
+		// given
+		// A malformed value must not break installs -- the function
+		// logs a warning and uses the default 10-minute timeout, so
+		// the fast test server still completes well inside the
+		// fallback ceiling.
+		expectedContent := "fallback-still-works"
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(expectedContent))
+		}))
+		defer server.Close()
+
+		t.Setenv(downloadTimeoutEnvVar, "this-is-not-a-duration")
+
+		tempDir := t.TempDir()
+		destPath := filepath.Join(tempDir, "downloaded_file")
+		osImpl := &entities.OSUnix{}
+
+		// when
+		err := osImpl.Download(server.URL, destPath)
+
+		// then
+		require.NoError(t, err)
+		content, readErr := os.ReadFile(destPath)
+		require.NoError(t, readErr)
+		assert.Equal(t, expectedContent, string(content))
 	})
 }

--- a/internal/domain/entities/os_download_test.go
+++ b/internal/domain/entities/os_download_test.go
@@ -88,9 +88,10 @@ func TestOSUnix_Download(t *testing.T) {
 func TestOSUnix_DownloadTimeout(t *testing.T) {
 	t.Run("should honor TERRA_DOWNLOAD_TIMEOUT when the response is slow", func(t *testing.T) {
 		// given
-		// Server sleeps longer than the configured override, so a
-		// correctly applied deadline will abort the body read with
-		// `context deadline exceeded` before the server replies.
+		// Server sleeps before writing headers, so a correctly
+		// applied deadline aborts the request while awaiting
+		// response headers with `context deadline exceeded` before
+		// the server replies.
 		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 			time.Sleep(500 * time.Millisecond)
 			w.WriteHeader(http.StatusOK)
@@ -110,6 +111,36 @@ func TestOSUnix_DownloadTimeout(t *testing.T) {
 		// then
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "deadline exceeded")
+	})
+
+	t.Run("should fall back to default when TERRA_DOWNLOAD_TIMEOUT is non-positive", func(t *testing.T) {
+		// given
+		// A non-positive value (zero or negative) parses fine but
+		// would make `context.WithTimeout` expire immediately and
+		// abort every download. The resolver must treat it as
+		// invalid and fall back to the default 10-minute ceiling so
+		// the fast test server completes successfully.
+		expectedContent := "non-positive-fallback-still-works"
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(expectedContent))
+		}))
+		defer server.Close()
+
+		t.Setenv(downloadTimeoutEnvVar, "0s")
+
+		tempDir := t.TempDir()
+		destPath := filepath.Join(tempDir, "downloaded_file")
+		osImpl := &entities.OSUnix{}
+
+		// when
+		err := osImpl.Download(server.URL, destPath)
+
+		// then
+		require.NoError(t, err)
+		content, readErr := os.ReadFile(destPath)
+		require.NoError(t, readErr)
+		assert.Equal(t, expectedContent, string(content))
 	})
 
 	t.Run("should fall back to default when TERRA_DOWNLOAD_TIMEOUT is malformed", func(t *testing.T) {


### PR DESCRIPTION
## Summary

\`downloadFile\` in \`internal/domain/entities/os.go\` wraps the entire HTTP request + body read in a \`context.WithTimeout\` whose deadline was hardcoded at 10 minutes. Go's \`http.Client\` respects the context for the *full* request lifetime, so when \`io.Copy(out, resp.Body)\` is reading the body, every \`Read()\` checks the context — a 600-second wall-clock cap on the whole download.

That ceiling fits HashiCorp's Cloudfront-served Terraform zip but **not** GitHub's S3-redirected Terragrunt binary, especially when the download runs under QEMU arm64 emulation on a multi-arch \`docker buildx --platform linux/amd64,linux/arm64\` build (each syscall pays user-mode binfmt translation, so the cumulative body read on a ~80 MB binary blows past 10 minutes). Failure mode is the silent:

\`\`\`
FATA Failed to download terragrunt: failed to write downloaded content to file: context deadline exceeded
\`\`\`

The constant is unreachable from outside the binary, so consumers had no remediation short of patching the source.

## Change

- \`defaultDownloadTimeout\` keeps the 10-minute default.
- New \`TERRA_DOWNLOAD_TIMEOUT\` env var overrides it. Accepts any \`time.ParseDuration\` value (\`30m\`, \`1h\`, \`20m30s\`).
- New helper \`resolveDownloadTimeout()\` reads the env var at every download call (not at init) so tests / operators can vary it without a process restart. A malformed value logs a warning via the existing \`logrus\` logger and falls back to the default — installs never silently break on a typo.
- \`time.ParseDuration\` is the canonical Go duration parser; no custom format.

## Tests

Two new tests under \`TestOSUnix_DownloadTimeout\`:

1. \`should honor TERRA_DOWNLOAD_TIMEOUT when the response is slow\` — sets \`100ms\`, hits a server that sleeps \`500ms\`, verifies the error contains \`deadline exceeded\`.
2. \`should fall back to default when TERRA_DOWNLOAD_TIMEOUT is malformed\` — sets a junk string, verifies the download still succeeds against a fast test server (default \`10m\` ceiling applied).

Tests live in a separate top-level test function (not subtests of \`TestOSUnix_Download\`) because \`t.Setenv\` is incompatible with \`t.Parallel()\` and the original test calls \`t.Parallel()\` at the parent level. \`make lint\` and \`go test -tags=unit ./...\` both pass.

## Docs

\`README.md\` Environment Configuration section gains a documented \`TERRA_DOWNLOAD_TIMEOUT=30m\` example with the rationale. \`CHANGELOG.md\` \`[Unreleased] > Added\` entry summarises the behaviour.

## Repro of the original failure

\`\`\`dockerfile
FROM ubuntu:24.04
RUN apt-get update && apt-get install -y curl file unzip ca-certificates
RUN curl -fsSL https://raw.githubusercontent.com/rios0rios0/terra/main/install.sh | sh -s -- --force
RUN cp \$HOME/.local/bin/terra /usr/local/bin/ && terra install
\`\`\`

\`\`\`bash
docker buildx build --platform linux/amd64,linux/arm64 .
\`\`\`

The arm64 leg fails on the Terragrunt download with \`context deadline exceeded\` after exactly 600 s. With this PR + \`TERRA_DOWNLOAD_TIMEOUT=30m\` set in the Dockerfile (\`ENV TERRA_DOWNLOAD_TIMEOUT=30m\` before \`terra install\`), the build completes.

## :vertical_traffic_light: Quality checklist

- [x] Did you add the changes in the \`CHANGELOG.md\`?
- [x] Did you run all the code checks? (\`go test\`)
- [x] Are the tests passing?