### PR TITLE
fix(upgrade): detect "Module source has changed" so auto init --upgrade fires on module source bumps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@ Exceptions are acceptable depending on the circumstances (critical bug fixes tha
 
 ## [Unreleased]
 
+### Fixed
+
+- fixed the auto `init --upgrade` detection inside `UpgradeAwareShellRepository` so it catches Terraform's `Module source has changed` diagnostic. Previously, when a module's `source` address changed (for example bumping its `?ref=` Git tag), `terra apply` failed with `Error: Module source has changed` and the reactive retry never fired -- Terraform's hint `Run "terraform init" to install all modules required by this configuration.` is split across two stderr lines by Terragrunt's per-line `<timestamp> STDERR <cmd>: │ ` prefix, so the existing `run "terraform init"` substring pattern in `getUpgradePatterns` could not match. Added two single-line patterns (`Module source has changed` and `source address was changed since this module was installed`) that survive the prefix wrap, plus BDD-style cases in `internal/infrastructure/repositories/upgrade_shell_repository_test.go` covering both a synthesized multi-line Terragrunt-prefixed sample and the standalone description sentence.
+
 ## [1.16.1] - 2026-05-04
 
 ### Fixed

--- a/internal/infrastructure/repositories/upgrade_shell_repository.go
+++ b/internal/infrastructure/repositories/upgrade_shell_repository.go
@@ -56,6 +56,13 @@ func getUpgradePatterns() []string {
 		// Module and plugin initialization.
 		"Module not installed",
 		"Required plugins are not installed",
+		// Module source change detection. The single-line diagnostic title
+		// "Module source has changed" (and the surrounding sentence) does not
+		// rely on the multi-line "Run \"terraform init\"" hint, which Terragrunt
+		// splits across stderr lines with its per-line "<ts> STDERR <cmd>: │ "
+		// prefix and therefore breaks the substring match used by needsUpgrade.
+		"Module source has changed",
+		"source address was changed since this module was installed",
 
 		// Provider version/lock file conflicts requiring init --upgrade.
 		"Inconsistent dependency lock file",

--- a/internal/infrastructure/repositories/upgrade_shell_repository_test.go
+++ b/internal/infrastructure/repositories/upgrade_shell_repository_test.go
@@ -79,6 +79,22 @@ func TestNeedsUpgrade(t *testing.T) {
 			"Error: Required plugins are not installed",
 		},
 		{
+			// The "Run \"terraform init\"" hint is split across two stderr lines
+			// by Terragrunt's per-line prefix, so the diagnostic title must catch it.
+			"should detect module source change via diagnostic title",
+			`HH:MM:SS.000 STDERR terraform: │ Error: Module source has changed
+HH:MM:SS.000 STDERR terraform: │
+HH:MM:SS.000 STDERR terraform: │   on example.tf line 1, in module "example":
+HH:MM:SS.000 STDERR terraform: │    1:   source = "git::https://example.invalid/modules/example.git?ref=v0.0.0"
+HH:MM:SS.000 STDERR terraform: │
+HH:MM:SS.000 STDERR terraform: │ The source address was changed since this module was installed. Run
+HH:MM:SS.000 STDERR terraform: │ "terraform init" to install all modules required by this configuration.`,
+		},
+		{
+			"should detect module source change via description sentence",
+			"The source address was changed since this module was installed.",
+		},
+		{
 			"should detect backend configuration changed",
 			"Error: Backend configuration changed. Please run terraform init",
 		},


### PR DESCRIPTION
## Summary

- Adds two single-line patterns (`Module source has changed` and `source address was changed since this module was installed`) to `getUpgradePatterns` in `internal/infrastructure/repositories/upgrade_shell_repository.go` so the reactive auto `init --upgrade` retry catches Terraform's "Module source has changed" diagnostic.
- The existing `run "terraform init"` substring pattern could not catch this case: Terragrunt prefixes every line of Terraform stderr with `<timestamp> STDERR <cmd>: │ `, splitting the hint `Run\n"terraform init" to install all modules required by this configuration.` across two lines. The substring `run "terraform init"` therefore never matched in the captured buffer, even with case-insensitive comparison.

## Failure pattern this fixes

When a module's `source` is bumped to a new Git ref, Terraform emits:

```
Error: Module source has changed

  on <file>.tf line N, in module "<name>":
   N:   source = "<git url>?ref=<new tag>"

The source address was changed since this module was installed. Run
"terraform init" to install all modules required by this configuration.
```

Terragrunt then prefixes every one of those lines with `<timestamp> STDERR terraform: │ ` before terra captures them, so the `Run\n"terraform init"` hint becomes two separate prefixed lines and the substring match fails. The reactive retry never fires and the apply aborts with `exit status 1`. After this PR, `Module source has changed` matches and the existing retry path runs `terragrunt init --upgrade` automatically.

## Why two patterns

- `Module source has changed` — the diagnostic title. Short, distinctive, single-line, future-proof against minor wording tweaks in the description.
- `source address was changed since this module was installed` — defence in depth, in case Terraform changes the title casing or wording in a future release.

Both phrases are unique enough to Terraform's module-source diagnostic that they won't false-positive on unrelated runtime errors.

## Why not a broader prefix-stripping fix

Stripping Terragrunt's per-line `<ts> STDERR <cmd>: │ ` prefix from the captured buffer before pattern matching would heal **all** future "run terraform init" cases at once, but it adds parsing logic that could mis-strip on future Terragrunt log format changes. Sticking with single-line patterns is the lowest-risk fix for the observed failure.

## Test plan

- [x] `go test -tags unit ./...` — all packages pass
- [x] 2 new BDD-style cases under `TestNeedsUpgrade`:
  - `should detect module source change via diagnostic title` — feeds a synthesized Terragrunt-prefixed multi-line sample
  - `should detect module source change via description sentence` — covers the standalone sentence
- [x] `make lint` — 0 issues

## :vertical_traffic_light: Quality checklist

- [x] Did you add the changes in the `CHANGELOG.md`?
- [x] Did you run all the code checks? (`go test`)
- [x] Are the tests passing?