### PR TITLE
fix(security): harden test directory permissions to owner-only (resolve Semgrep incorrect-default-permission)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,10 @@ Exceptions are acceptable depending on the circumstances (critical bug fixes tha
 
 - changed the Go module dependencies to their latest versions
 
+### Security
+
+- hardened test-fixture directory permissions from `0o755` to owner-only `0o700` (and the executable fake-CLI `Chmod` likewise), resolving the Semgrep `incorrect-default-permission` CI failures (a directory needs the owner execute bit, so the rule's `0o600` file threshold is documented as inapplicable and suppressed per line)
+
 ## [1.17.2] - 2026-07-14
 
 ### Changed

--- a/cmd/terra/parallel_prefix_e2e_test.go
+++ b/cmd/terra/parallel_prefix_e2e_test.go
@@ -90,7 +90,8 @@ func TestParallelOutputPrefix_E2E(t *testing.T) {
 
 	// 2. Fake terragrunt + terraform on an isolated PATH bin directory.
 	fakeBin := filepath.Join(tmp, "bin")
-	require.NoError(t, os.MkdirAll(fakeBin, 0o755))
+	// nosemgrep: go.lang.correctness.permissions.file_permission.incorrect-default-permission
+	require.NoError(t, os.MkdirAll(fakeBin, 0o700))
 	writeFakeCLI(t, filepath.Join(fakeBin, "terragrunt"))
 	writeFakeCLI(t, filepath.Join(fakeBin, "terraform"))
 
@@ -98,7 +99,8 @@ func TestParallelOutputPrefix_E2E(t *testing.T) {
 	modulesDir := filepath.Join(tmp, "modules")
 	for _, module := range []string{"module-a", "module-b"} {
 		dir := filepath.Join(modulesDir, module)
-		require.NoError(t, os.MkdirAll(dir, 0o755))
+		// nosemgrep: go.lang.correctness.permissions.file_permission.incorrect-default-permission
+		require.NoError(t, os.MkdirAll(dir, 0o700))
 		require.NoError(t, os.WriteFile(
 			filepath.Join(dir, "terragrunt.hcl"), []byte("# fake\n"), 0o644))
 	}
@@ -106,7 +108,8 @@ func TestParallelOutputPrefix_E2E(t *testing.T) {
 	// 4. Fully isolated environment for the terra subprocess. A sandbox HOME means even the
 	//    ~/.local/bin and ~/.cache fallbacks resolve inside t.TempDir().
 	sandboxHome := filepath.Join(tmp, "home")
-	require.NoError(t, os.MkdirAll(sandboxHome, 0o755))
+	// nosemgrep: go.lang.correctness.permissions.file_permission.incorrect-default-permission
+	require.NoError(t, os.MkdirAll(sandboxHome, 0o700))
 	env := append(os.Environ(),
 		"HOME="+sandboxHome,
 		"PATH="+fakeBin+string(os.PathListSeparator)+os.Getenv("PATH"),

--- a/internal/domain/commands/run_additional_before_command_test.go
+++ b/internal/domain/commands/run_additional_before_command_test.go
@@ -257,7 +257,8 @@ func TestRunAdditionalBeforeCommand_Execute_EnvironmentInit(t *testing.T) {
 		repository := &repositorydoubles.StubShellRepositoryForAdditional{}
 		cmd := commands.NewRunAdditionalBeforeCommand(settings, nil, repository)
 		targetPath := t.TempDir()
-		require.NoError(t, os.MkdirAll(filepath.Join(targetPath, ".terraform"), 0o755))
+		// nosemgrep: go.lang.correctness.permissions.file_permission.incorrect-default-permission
+		require.NoError(t, os.MkdirAll(filepath.Join(targetPath, ".terraform"), 0o700))
 		arguments := []string{"plan"}
 
 		// WHEN: Executing the command
@@ -281,7 +282,8 @@ func TestRunAdditionalBeforeCommand_Execute_EnvironmentInit(t *testing.T) {
 		repository := &repositorydoubles.StubShellRepositoryForAdditional{}
 		cmd := commands.NewRunAdditionalBeforeCommand(settings, nil, repository)
 		targetPath := t.TempDir()
-		require.NoError(t, os.MkdirAll(filepath.Join(targetPath, ".terragrunt-cache"), 0o755))
+		// nosemgrep: go.lang.correctness.permissions.file_permission.incorrect-default-permission
+		require.NoError(t, os.MkdirAll(filepath.Join(targetPath, ".terragrunt-cache"), 0o700))
 		arguments := []string{"apply"}
 
 		// WHEN: Executing the command
@@ -305,7 +307,8 @@ func TestRunAdditionalBeforeCommand_Execute_EnvironmentInit(t *testing.T) {
 		repository := &repositorydoubles.StubShellRepositoryForAdditional{}
 		cmd := commands.NewRunAdditionalBeforeCommand(settings, nil, repository)
 		targetPath := t.TempDir()
-		require.NoError(t, os.MkdirAll(filepath.Join(targetPath, "terragrunt-cache"), 0o755))
+		// nosemgrep: go.lang.correctness.permissions.file_permission.incorrect-default-permission
+		require.NoError(t, os.MkdirAll(filepath.Join(targetPath, "terragrunt-cache"), 0o700))
 		arguments := []string{"apply"}
 
 		// WHEN: Executing the command
@@ -389,7 +392,8 @@ func TestRunAdditionalBeforeCommand_Execute_CentralizedCache(t *testing.T) {
 		cmd := commands.NewRunAdditionalBeforeCommand(settings, nil, repository)
 		targetPath := t.TempDir()
 		cacheDir := t.TempDir()
-		require.NoError(t, os.MkdirAll(filepath.Join(cacheDir, "someHashDir"), 0o755))
+		// nosemgrep: go.lang.correctness.permissions.file_permission.incorrect-default-permission
+		require.NoError(t, os.MkdirAll(filepath.Join(cacheDir, "someHashDir"), 0o700))
 		t.Setenv("TG_DOWNLOAD_DIR", cacheDir)
 		arguments := []string{"apply"}
 

--- a/internal/infrastructure/repositories/upgrade_shell_repository_test.go
+++ b/internal/infrastructure/repositories/upgrade_shell_repository_test.go
@@ -23,7 +23,10 @@ func writeExecutableScript(t *testing.T, path, content string) {
 	cmd := exec.Command("sh", "-c", `cat > "$1"`, "sh", path)
 	cmd.Stdin = strings.NewReader(content)
 	require.NoError(t, cmd.Run())
-	require.NoError(t, os.Chmod(path, 0o755)) //nolint:gosec // Test script with intentional permissions
+	// The script is executed by the test, so it needs the owner execute bit; 0o700 is the
+	// least-privilege mode for an owner-run executable.
+	// nosemgrep: go.lang.correctness.permissions.file_permission.incorrect-default-permission
+	require.NoError(t, os.Chmod(path, 0o700))
 }
 
 func TestNewUpgradeAwareShellRepository(t *testing.T) {


### PR DESCRIPTION
## Problem

CI `sast:semgrep` fails on `main` with 8 blocking findings, all of the same rule:

```
go.lang.correctness.permissions.file_permission.incorrect-default-permission
```

The rule (a gosec G301/G302 port, CWE-276) flags `os.Chmod/Mkdir/OpenFile/MkdirAll/ioutil.WriteFile` whenever the mode is **strictly greater than `0o600`**.

## Root cause

All 8 findings are in test files — 7 `os.MkdirAll(..., 0o755)` directory creations plus 1 `os.Chmod(script, 0o755)` on a fake CLI the test executes:

- `cmd/terra/parallel_prefix_e2e_test.go` (fake bin dir, module dirs, sandbox HOME)
- `internal/domain/commands/run_additional_before_command_test.go` (terraform/terragrunt cache dirs)
- `internal/infrastructure/repositories/upgrade_shell_repository_test.go` (executable fake-CLI script)

Two facts drive the fix:

1. `0o755` grants group/world access these test fixtures never need — `0o700` is a genuine least-privilege improvement (the script still runs; the test executes it as the owner).
2. A directory must keep the owner *execute* (search) bit or files cannot be created/read inside it (`0o600` dir ⇒ `permission denied`), and an executable script needs the owner execute bit. So the rule's `0o600` threshold cannot be met; `0o700` is the least-privilege mode.

## Fix

- **Hardened** every flagged `os.MkdirAll` and the `os.Chmod` from `0o755` to owner-only **`0o700`**.
- Added a **rule-scoped** `// nosemgrep: go.lang.correctness.permissions.file_permission.incorrect-default-permission` for the irreducible residual; the executable-script site carries an inline rationale.
- Dropped the now-redundant `//nolint:gosec` on the `Chmod` — gosec is already excluded from `_test.go` by the shared lint config.
- `CHANGELOG.md` updated under `[Unreleased] > Security`.

Note: `os.WriteFile(fakeCLI, 0o755)` is intentionally left as-is — it writes an executable and is not matched by this rule (`os.WriteFile` is out of scope; only `ioutil.WriteFile` is).

Verified locally: `golangci-lint` (pipelines config, `unit`+`integration` tags) `--new-from-rev origin/main` → 0 new issues; `go vet` compiles; `gofmt` clean; the directive suppresses all findings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)